### PR TITLE
Add Manual "Force Update Filterlist" Button to Settings Page

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -486,6 +486,14 @@ async function setupUpdateSchedule() {
 
 // Event Listeners
 browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "forceUpdateFilterlist") {
+    fetchFilterLists().then(() => {
+      if (sendResponse) sendResponse({ status: "ok" });
+    }).catch((err) => {
+      if (sendResponse) sendResponse({ status: "error", error: err?.toString() });
+    });
+    return true; // Indicates async response
+  }
   if (message.action === "checkSiteStatus") {
     const { url, rootUrl } = message;
 

--- a/src/pub/settings-page.html
+++ b/src/pub/settings-page.html
@@ -525,6 +525,9 @@
             </svg>
             Next update scheduled for: Checking...
           </div>
+          <div style="text-align: right; margin-top: 0.75rem;">
+            <button id="forceRefresh" class="btn" style="padding: 0.5rem 1.25rem; font-size: 0.9rem;">Force Update Filterlist</button>
+          </div>
         </div>
 
         <!-- Appearance -->

--- a/src/pub/settings-page.js
+++ b/src/pub/settings-page.js
@@ -1,4 +1,21 @@
 document.addEventListener("DOMContentLoaded", () => {
+  if (forceRefreshButton) {
+    forceRefreshButton.addEventListener("click", async () => {
+      forceRefreshButton.disabled = true;
+      forceRefreshButton.textContent = "Updating...";
+      try {
+        await browserAPI.runtime.sendMessage({ action: "forceUpdateFilterlist" });
+        showNotification("Filterlist update started.");
+      } catch (error) {
+        showNotification("Failed to start update.", true);
+      } finally {
+        setTimeout(() => {
+          forceRefreshButton.disabled = false;
+          forceRefreshButton.textContent = "Force Update Filterlist";
+        }, 2000);
+      }
+    });
+  }
   // Cross-browser compatibility shim
   const browserAPI = typeof browser !== "undefined" ? browser : chrome;
   // Load and display the extension version from manifest.json


### PR DESCRIPTION
Summary:

Added a "Force Update Filterlist" button to the settings page, under the filterlist statistics section.
Clicking the button immediately triggers a manual filterlist update by messaging the background script to run the update logic ([fetchFilterLists()](https://sturdy-broccoli-vwjx9g7vr5w3ppv4.github.dev/)).
The button is disabled and shows "Updating..." while the update is in progress, then re-enables after a short delay.
This provides users with a workaround for cases where automatic updates are not working, especially on Firefox.
Rationale:
Addresses user reports that filterlist updates remain pending and never install automatically on Firefox, with no way to manually force an update except by reinstalling the extension.

Fixes https://github.com/fmhy/FMHY-SafeGuard/issues/27

Files changed:

[settings-page.html](https://sturdy-broccoli-vwjx9g7vr5w3ppv4.github.dev/)
[settings-page.js](https://sturdy-broccoli-vwjx9g7vr5w3ppv4.github.dev/)
[background.js](https://sturdy-broccoli-vwjx9g7vr5w3ppv4.github.dev/)