### PR TITLE
Add Safari WebExtension source port

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Install Dependencies
         run: |
           sudo apt-get update
@@ -85,6 +90,12 @@ jobs:
           cd ..
           mv FMHY-SafeGuard_${{ env.VERSION }}.firefox.zip FMHY-SafeGuard_${{ env.VERSION }}.firefox.xpi
 
+      - name: Build Safari Source Extension
+        run: |
+          node scripts/build-safari-source.mjs
+          cd dist/safari
+          zip -r ../FMHY-SafeGuard_${{ env.VERSION }}.safari-source.zip ./*
+
       - name: Upload Chrome Extension
         uses: actions/upload-release-asset@v1
         env:
@@ -104,3 +115,13 @@ jobs:
           asset_path: dist/FMHY-SafeGuard_${{ env.VERSION }}.firefox.xpi
           asset_name: FMHY-SafeGuard_${{ env.VERSION }}.firefox.xpi
           asset_content_type: application/x-xpinstall
+
+      - name: Upload Safari Source Extension
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/FMHY-SafeGuard_${{ env.VERSION }}.safari-source.zip
+          asset_name: FMHY-SafeGuard_${{ env.VERSION }}.safari-source.zip
+          asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -92,3 +92,7 @@ For questions or support, feel free to open an issue on [GitHub](https://github.
 - [FMHY Edit](https://github.com/fmhy/edit), the service used to detect safe sites, created by FMHY
 - [FMHY Related Sites/Projects List](https://github.com/fmhy/FMHY-SafeGuard/blob/main/fmhy-filterlist.txt), the service used to detect FMHY related sites/projects, created by FMHY
 - [Kenneth Hendricks](https://github.com/kenhendricks00), the original creator of the FMHY SafeGuard Extension
+
+# Safari Source Build
+
+Safari Web Extension source setup is documented in [docs/Safari.md](docs/Safari.md). Windows can prepare `dist/safari`, while final Safari conversion, signing, and in-browser testing still require macOS with Xcode.

--- a/docs/Safari.md
+++ b/docs/Safari.md
@@ -1,0 +1,59 @@
+# Safari Web Extension Source Build
+
+FMHY SafeGuard now includes a Safari Web Extension source manifest so the shared `src/` code can be reused for Safari with minimal platform-specific changes.
+
+## What Windows, Linux, and macOS can do
+
+- Edit the shared extension source code.
+- Build the Safari source bundle at `dist/safari`.
+- Run manifest validation and other Node-based checks.
+
+## What requires macOS
+
+- Running `safari-web-extension-converter`.
+- Generating the Xcode project.
+- Signing the app or extension.
+- Testing inside Safari.
+- Distributing through TestFlight or the App Store.
+
+## Commands
+
+Build the Safari source folder:
+
+```bash
+node scripts/build-safari-source.mjs
+```
+
+Validate the manifests:
+
+```bash
+node scripts/validate-manifests.mjs
+```
+
+Convert the Safari source into an Xcode project on macOS:
+
+```bash
+bash scripts/convert-safari-macos.sh
+```
+
+## Expected output
+
+- `dist/safari`
+- `safari/FMHY-SafeGuard-Safari` after running the macOS conversion helper
+
+## Notes about release artifacts
+
+Any Safari asset produced by CI is source-only. It is intended for `safari-web-extension-converter` and is not directly installable as a signed Safari extension.
+
+## Testing checklist
+
+- Extension installs in Safari after conversion.
+- Popup opens correctly.
+- Options page works.
+- First-run welcome page opens on install.
+- Remote FMHY filter lists fetch from GitHub raw URLs.
+- Toolbar icon changes with site status.
+- Search result highlighting works on Google, DuckDuckGo, Bing, and Brave Search.
+- Unsafe site warning redirect works.
+- Force update works from settings.
+- Scheduled update still works after Safari or background restarts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "fmhy-safeguard",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fmhy-safeguard"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fmhy-safeguard",
+  "private": true,
+  "scripts": {
+    "build:safari-source": "node scripts/build-safari-source.mjs",
+    "validate:manifests": "node scripts/validate-manifests.mjs"
+  }
+}

--- a/platform/safari/manifest.json
+++ b/platform/safari/manifest.json
@@ -1,0 +1,94 @@
+{
+  "manifest_version": 3,
+  "name": "__MSG_extensionName__",
+  "default_locale": "en",
+  "author": "Kenneth Hendricks & contributors",
+  "version": "1.3.6",
+  "icons": {
+    "128": "res/ext_icon_144.png"
+  },
+  "action": {
+    "default_icon": {
+      "128": "res/ext_icon_144.png"
+    },
+    "default_popup": "pub/index.html"
+  },
+  "options_page": "pub/settings-page.html",
+  "permissions": [
+    "storage",
+    "tabs",
+    "alarms",
+    "contextMenus"
+  ],
+  "host_permissions": [
+    "https://raw.githubusercontent.com/*"
+  ],
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.google.com/*",
+        "*://*.google.co.uk/*",
+        "*://*.google.de/*",
+        "*://*.google.fr/*",
+        "*://*.google.it/*",
+        "*://*.google.es/*",
+        "*://*.google.nl/*",
+        "*://*.google.ca/*",
+        "*://*.google.com.au/*",
+        "*://*.google.com.br/*",
+        "*://*.google.co.jp/*",
+        "*://*.google.co.kr/*",
+        "*://*.google.co.in/*",
+        "*://*.google.ru/*",
+        "*://*.google.cn/*",
+        "*://*.bing.com/*",
+        "*://*.duckduckgo.com/*",
+        "*://*.librey.org/*",
+        "*://*.4get.ca/*",
+        "*://*.mojeek.com/*",
+        "*://*.qwant.com/*",
+        "*://*.swisscows.com/*",
+        "*://*.yacy.net/*",
+        "*://*.startpage.com/*",
+        "*://*.search.brave.com/*",
+        "*://*.ekoru.org/*",
+        "*://*.gibiru.com/*",
+        "*://*.searx.org/*",
+        "*://*.metager.org/*",
+        "*://*.ecosia.org/*",
+        "*://*.yandex.com/*",
+        "*://*.yandex.ru/*",
+        "*://*.yandex.ua/*",
+        "*://*.yandex.kz/*",
+        "*://*.yandex.by/*",
+        "*://*.yandex.tr/*",
+        "*://*.yahoo.com/*",
+        "*://*.yahoo.co.jp/*",
+        "*://*.yahoo.co.uk/*",
+        "*://*.yahoo.de/*",
+        "*://*.yahoo.fr/*",
+        "*://*.yahoo.it/*",
+        "*://*.yahoo.es/*",
+        "*://*.yahoo.ca/*",
+        "*://*.yahoo.com.au/*",
+        "*://*.yahoo.com.br/*",
+        "*://*.yahoo.co.kr/*",
+        "*://*.yahoo.co.in/*",
+        "*://*.baidu.com/*",
+        "*://*.naver.com/*",
+        "*://*.seznam.cz/*"
+      ],
+      "js": [
+        "js/content.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
+  "background": {
+    "scripts": [
+      "js/background.js"
+    ],
+    "service_worker": "js/background.js"
+  },
+  "description": "__MSG_extensionDescription__"
+}

--- a/scripts/build-safari-source.mjs
+++ b/scripts/build-safari-source.mjs
@@ -1,0 +1,25 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+const srcDir = path.join(repoRoot, "src");
+const safariManifest = path.join(repoRoot, "platform", "safari", "manifest.json");
+const distRoot = path.join(repoRoot, "dist");
+const distSafari = path.join(distRoot, "safari");
+
+async function buildSafariSource() {
+  await rm(distSafari, { recursive: true, force: true });
+  await mkdir(distRoot, { recursive: true });
+  await cp(srcDir, distSafari, { recursive: true });
+  await cp(safariManifest, path.join(distSafari, "manifest.json"));
+
+  console.log(`Safari source prepared at ${distSafari}`);
+}
+
+buildSafariSource().catch((error) => {
+  console.error("Failed to build Safari source:", error);
+  process.exitCode = 1;
+});

--- a/scripts/convert-safari-macos.sh
+++ b/scripts/convert-safari-macos.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "Safari conversion requires macOS with Xcode command line tools."
+  echo "Run 'node scripts/build-safari-source.mjs' on Windows/Linux to prepare dist/safari, then run this script on macOS."
+  exit 1
+fi
+
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "xcrun was not found. Install Xcode command line tools first."
+  exit 1
+fi
+
+if ! xcrun --find safari-web-extension-converter >/dev/null 2>&1; then
+  echo "safari-web-extension-converter is not available. Install Xcode and Safari development tools first."
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+node scripts/build-safari-source.mjs
+
+xcrun safari-web-extension-converter dist/safari \
+  --project-location safari/FMHY-SafeGuard-Safari \
+  --app-name "FMHY SafeGuard"

--- a/scripts/validate-manifests.mjs
+++ b/scripts/validate-manifests.mjs
@@ -1,0 +1,69 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const manifestPaths = {
+  chromium: path.join(repoRoot, "platform", "chromium", "manifest.json"),
+  firefox: path.join(repoRoot, "platform", "firefox", "manifest.json"),
+  safari: path.join(repoRoot, "platform", "safari", "manifest.json"),
+};
+
+const requiredSafariPermissions = ["storage", "tabs", "alarms", "contextMenus"];
+
+async function loadManifest(platform, manifestPath) {
+  try {
+    const raw = await readFile(manifestPath, "utf8");
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${platform} manifest is invalid: ${error.message}`);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function validateSafariManifest(manifest) {
+  assert(manifest.manifest_version === 3, "Safari manifest must use manifest_version 3");
+  assert(manifest.name === "__MSG_extensionName__", "Safari manifest must keep the localized extension name");
+  assert(manifest.default_locale === "en", "Safari manifest must set default_locale to en");
+  assert(typeof manifest.version === "string" && manifest.version.length > 0, "Safari manifest must include a version");
+  assert(manifest.icons && typeof manifest.icons === "object", "Safari manifest must include icons");
+  assert(manifest.action?.default_popup === "pub/index.html", "Safari manifest must include the popup");
+  assert(manifest.options_page === "pub/settings-page.html", "Safari manifest must include the options page");
+  assert(Array.isArray(manifest.content_scripts) && manifest.content_scripts.length > 0, "Safari manifest must include content_scripts");
+
+  const permissions = Array.isArray(manifest.permissions) ? manifest.permissions : [];
+  for (const permission of requiredSafariPermissions) {
+    assert(permissions.includes(permission), `Safari manifest must include permission: ${permission}`);
+  }
+
+  const hostPermissions = Array.isArray(manifest.host_permissions) ? manifest.host_permissions : [];
+  assert(
+    hostPermissions.includes("https://raw.githubusercontent.com/*"),
+    "Safari manifest must include https://raw.githubusercontent.com/* in host_permissions"
+  );
+}
+
+async function main() {
+  const manifests = {};
+
+  for (const [platform, manifestPath] of Object.entries(manifestPaths)) {
+    manifests[platform] = await loadManifest(platform, manifestPath);
+  }
+
+  validateSafariManifest(manifests.safari);
+
+  console.log("Manifest validation passed for chromium, firefox, and safari.");
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -2,6 +2,44 @@
 const browserAPI = typeof browser !== "undefined" ? browser : chrome;
 const contextMenuIdOpenFmhy = "open-fmhy-net";
 const fmhyWebsiteURL = "https://fmhy.net/";
+const syncStorage = browserAPI.storage?.sync ?? browserAPI.storage?.local;
+
+async function getFromStorage(area, keys) {
+  if (!area?.get) {
+    return {};
+  }
+
+  return area.get(keys);
+}
+
+async function getWarningPageSetting() {
+  const localSettings = await getFromStorage(browserAPI.storage?.local, {
+    showWarning: true,
+  });
+
+  if (syncStorage?.get && syncStorage !== browserAPI.storage?.local) {
+    const syncSettings = await getFromStorage(syncStorage, {
+      warningPage: localSettings.showWarning,
+    });
+
+    if (syncSettings.warningPage !== undefined) {
+      return syncSettings.warningPage;
+    }
+  }
+
+  return localSettings.showWarning !== false;
+}
+
+function updateActionIcon(tabId, path) {
+  if (!browserAPI.action?.setIcon) {
+    return;
+  }
+
+  browserAPI.action.setIcon({
+    tabId,
+    path,
+  });
+}
 
 // Open welcome page on first install
 browserAPI.runtime.onInstalled.addListener((details) => {
@@ -19,18 +57,24 @@ browserAPI.runtime.onStartup?.addListener(() => {
   createExtensionContextMenu();
 });
 
-function createExtensionContextMenu() {
+async function createExtensionContextMenu() {
   if (!browserAPI.contextMenus?.create) {
     return;
   }
 
+  try {
+    if (browserAPI.contextMenus.remove) {
+      await browserAPI.contextMenus.remove(contextMenuIdOpenFmhy);
+    }
+  } catch (error) {
+    // Ignore missing-menu errors and recreate the entry below.
+  }
+
   // Remove only this extension menu item to avoid affecting future entries.
-  browserAPI.contextMenus.remove(contextMenuIdOpenFmhy, () => {
-    browserAPI.contextMenus.create({
-      id: contextMenuIdOpenFmhy,
-      title: "Open FMHY.net",
-      contexts: ["action"]
-    });
+  browserAPI.contextMenus.create({
+    id: contextMenuIdOpenFmhy,
+    title: "Open FMHY.net",
+    contexts: ["action"]
   });
 }
 
@@ -869,10 +913,7 @@ function updatePageAction(status, tabId) {
 
   const icon = icons[status] || icons["default"];
 
-  browserAPI.action.setIcon({
-    tabId: tabId,
-    path: icon,
-  });
+  updateActionIcon(tabId, icon);
 }
 
 async function notifySettingsPage() {
@@ -980,6 +1021,11 @@ async function shouldUpdate() {
 }
 
 async function setupUpdateSchedule() {
+  if (!browserAPI.alarms?.create || !browserAPI.alarms?.clearAll) {
+    console.warn("Alarms API is unavailable; scheduled updates are disabled.");
+    return;
+  }
+
   await browserAPI.alarms.clearAll();
 
   // Get the user's preferred update frequency from storage
@@ -1371,11 +1417,9 @@ async function openWarningPage(tabId, unsafeUrl) {
   }
 
   // Fetch the warning page setting
-  const { warningPage } = await browserAPI.storage.sync.get({
-    warningPage: true,
-  });
+  const warningPageEnabled = await getWarningPageSetting();
 
-  if (!warningPage) {
+  if (!warningPageEnabled) {
     console.log("Warning page is disabled by the user settings.");
     return;
   }
@@ -1430,7 +1474,7 @@ browserAPI.tabs.onActivated.addListener(async (activeInfo) => {
   }
 });
 
-browserAPI.alarms.onAlarm.addListener(async (alarm) => {
+browserAPI.alarms?.onAlarm?.addListener(async (alarm) => {
   if (alarm.name === "checkUpdate") {
     const needsUpdate = await shouldUpdate();
     if (needsUpdate) {
@@ -1657,20 +1701,23 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const { tabId, url } = message;
     const rootUrl = extractRootUrl(url);
 
-    // Fetch existing approved URLs from storage
-    browserAPI.storage.local.get("approvedUrls", (result) => {
+    (async () => {
+      const result = await browserAPI.storage.local.get("approvedUrls");
       const approvedUrls = result.approvedUrls || [];
 
       // Add the root URL if not already approved
       if (!approvedUrls.includes(rootUrl)) {
         approvedUrls.push(rootUrl);
-        browserAPI.storage.local.set({ approvedUrls });
+        await browserAPI.storage.local.set({ approvedUrls });
         console.log(`approveSite: ${rootUrl} approved globally.`);
       }
 
       // Set the toolbar icon to "unsafe" immediately
       updatePageAction("unsafe", tabId);
       sendResponse({ status: "approved" });
+    })().catch((error) => {
+      console.error("approveSite failed:", error);
+      sendResponse({ status: "error", error: error.message });
     });
     return true;
   }

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -7,7 +7,7 @@
 const browserAPI = typeof browser !== "undefined" ? browser : chrome;
 
 // Track processed elements to avoid reprocessing
-const processedLinks = new WeakSet();
+let processedLinks = new WeakSet();
 const processedDomains = new Set();
 const highlightCountTrusted = new Map();
 const highlightCountUntrusted = new Map();


### PR DESCRIPTION
## Summary

Adds a Safari WebExtension source port while preserving existing Chromium and Firefox support.

## Changes

- Added `platform/safari/manifest.json`
- Added cross-platform Safari source build script
- Added macOS Safari conversion helper
- Added manifest validation script
- Added package scripts for validation and Safari source generation
- Fixed `processedLinks` reassignment bug in `content.js`
- Added Safari compatibility guards in `background.js`
- Updated release workflow to publish a Safari source zip
- Added Safari build/testing documentation

## Validation

Tested on macOS with Safari:

- `npm install`
- `npm run validate:manifests`
- `npm run build:safari-source`
- `bash scripts/convert-safari-macos.sh`
- Opened generated Xcode project
- Built and ran macOS Safari extension
- Enabled extension in Safari
- Verified the extension works in Safari

## Notes

The Safari release artifact is a source package for Safari/Xcode conversion, not a directly installable Safari extension. Final Safari packaging/signing still requires macOS and Xcode.
