### PR TITLE
Scope FMHY status to listed resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@
 - Prevented toolbar icons from falling back to root-domain status on shared hosts.
 - Removed trailing slashes from root-only popup labels and restored starred GitHub Gists and GitLab Snippets alternatives.
 - Scoped additional multi-tenant platforms by path, query, and fragment identifiers.
-- Preserved FMHY status across canonical same-resource and navigation-scoped cross-domain redirects.
-- Prevented popup and toolbar checks from running before live list initialization completes.
-- Added a Firefox-compatible redirect tracker when `webNavigation.onBeforeRedirect` is unavailable.
-- Used Firefox `webRequest` main-frame redirect events when navigation commits omit the source URL.
+- Matched Greasy Fork script redirects by their stable numeric script ID.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Removed trailing slashes from root-only popup labels and restored starred GitHub Gists and GitLab Snippets alternatives.
 - Scoped additional multi-tenant platforms by path, query, and fragment identifiers.
 - Preserved FMHY status across canonical same-resource and navigation-scoped cross-domain redirects.
+- Prevented popup and toolbar checks from running before live list initialization completes.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Preserved Codeberg owner and repository names in popup status labels.
+- Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Prevented toolbar icons from falling back to root-domain status on shared hosts.
 - Removed trailing slashes from root-only popup labels and restored starred GitHub Gists and GitLab Snippets alternatives.
 - Scoped additional multi-tenant platforms by path, query, and fragment identifiers.
+- Preserved FMHY status across canonical same-resource and navigation-scoped cross-domain redirects.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.
 - Kept toolbar icons aligned with path-specific unsafe classifications shown in the popup.
-- Displayed the active subdomain when it inherits a parent domain's FMHY status.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.
 - Kept toolbar icons aligned with path-specific unsafe classifications shown in the popup.
+- Displayed the active subdomain when it inherits a parent domain's FMHY status.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Require real URL and hostname boundaries when matching filter-list entries.
+- Render unsafe reasons as text and safe links instead of injecting remote HTML.
 - Parse Markdown autolinks such as `<https://rentry.co/...>` as FMHY resources and map them to their guide sections.
 
 - Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Parse Markdown autolinks such as `<https://rentry.co/...>` as FMHY resources and map them to their guide sections.
+
 - Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.
 - Kept toolbar icons aligned with path-specific unsafe classifications shown in the popup.
 - Distinguished starred Ente Auth redirects as canonical `ente.com/auth` resources instead of the safe Ente homepage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.
 - Kept toolbar icons aligned with path-specific unsafe classifications shown in the popup.
 - Distinguished starred Ente Auth redirects as canonical `ente.com/auth` resources instead of the safe Ente homepage.
+- Scoped Linktree classifications to individual profiles so unsafe resources cannot inherit the starred root status.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Scoped Linktree classifications to individual profiles so unsafe resources cannot inherit the starred root status.
 - Prevented toolbar icons from falling back to root-domain status on shared hosts.
 - Removed trailing slashes from root-only popup labels and restored starred GitHub Gists and GitLab Snippets alternatives.
+- Scoped additional multi-tenant platforms by path, query, and fragment identifiers.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.
+- Kept toolbar icons aligned with path-specific unsafe classifications shown in the popup.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
+- Added path-aware unsafe reasons for repository and link-aggregator resources.
 
 ## v1.3.7 (07/10/2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.
+- Replaced the branded popup icon with a neutral status icon when a site is not listed in FMHY.
 
 ## v1.3.7 (07/10/2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Scoped additional multi-tenant platforms by path, query, and fragment identifiers.
 - Preserved FMHY status across canonical same-resource and navigation-scoped cross-domain redirects.
 - Prevented popup and toolbar checks from running before live list initialization completes.
+- Added a Firefox-compatible redirect tracker when `webNavigation.onBeforeRedirect` is unavailable.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Preserved FMHY status across canonical same-resource and navigation-scoped cross-domain redirects.
 - Prevented popup and toolbar checks from running before live list initialization completes.
 - Added a Firefox-compatible redirect tracker when `webNavigation.onBeforeRedirect` is unavailable.
+- Used Firefox `webRequest` main-frame redirect events when navigation commits omit the source URL.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Kept toolbar icons aligned with path-specific unsafe classifications shown in the popup.
 - Distinguished starred Ente Auth redirects as canonical `ente.com/auth` resources instead of the safe Ente homepage.
 - Scoped Linktree classifications to individual profiles so unsafe resources cannot inherit the starred root status.
+- Prevented toolbar icons from falling back to root-domain status on shared hosts.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,26 @@
 
 ## Unreleased
 
-- Check every changed tab URL immediately so status and toolbar icons update before page completion, with earlier warning redirects for unsafe sites.
-- Require real URL and hostname boundaries when matching filter-list entries.
-- Render unsafe reasons as text and safe links instead of injecting remote HTML.
-- Parse Markdown autolinks such as `<https://rentry.co/...>` as FMHY resources and map them to their guide sections.
-
+#### **🔧 Enhancements**
+- Checked every changed tab URL immediately so status and toolbar icons update before page completion, with earlier warning redirects for unsafe sites.
 - Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.
+- Removed trailing slashes from root-only popup labels.
+- Matched Greasy Fork script redirects by their stable numeric script ID.
+- Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
+- Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
+- Replaced the branded popup icon with a neutral status icon when a site is not listed in FMHY.
+
+#### **🐞 Bug Fixes**
+- Required real URL and hostname boundaries when matching filter-list entries.
+- Rendered unsafe reasons as text and safe links instead of injecting remote HTML.
+- Parsed Markdown autolinks such as `<https://rentry.co/...>` as FMHY resources and mapped them to their guide sections.
 - Kept toolbar icons aligned with path-specific unsafe classifications shown in the popup.
 - Distinguished starred Ente Auth redirects as canonical `ente.com/auth` resources instead of the safe Ente homepage.
 - Scoped Linktree classifications to individual profiles so unsafe resources cannot inherit the starred root status.
 - Prevented toolbar icons from falling back to root-domain status on shared hosts.
-- Removed trailing slashes from root-only popup labels and restored starred GitHub Gists and GitLab Snippets alternatives.
+- Restored starred GitHub Gists and GitLab Snippets alternatives.
 - Scoped additional multi-tenant platforms by path, query, and fragment identifiers.
-- Matched Greasy Fork script redirects by their stable numeric script ID.
-- Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
-- Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.
-- Replaced the branded popup icon with a neutral status icon when a site is not listed in FMHY.
 - Made starred and safe matching resource-aware so shared hosts and sibling repositories cannot inherit each other's status.
 
 ## v1.3.7 (07/10/2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Distinguished starred Ente Auth redirects as canonical `ente.com/auth` resources instead of the safe Ente homepage.
 - Scoped Linktree classifications to individual profiles so unsafe resources cannot inherit the starred root status.
 - Prevented toolbar icons from falling back to root-domain status on shared hosts.
+- Removed trailing slashes from root-only popup labels and restored starred GitHub Gists and GitLab Snippets alternatives.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Preserved resource paths in popup status labels for Codeberg, Rentry, and other shared hosts.
 - Kept toolbar icons aligned with path-specific unsafe classifications shown in the popup.
+- Distinguished starred Ente Auth redirects as canonical `ente.com/auth` resources instead of the safe Ente homepage.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
+- Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
+
 ## v1.3.7 (07/10/2026)
 
 #### **🚀 New Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Check changed tab URLs immediately so unsafe-page warnings appear before page completion.
+- Check every changed tab URL immediately so status and toolbar icons update before page completion, with earlier warning redirects for unsafe sites.
 - Require real URL and hostname boundaries when matching filter-list entries.
 - Render unsafe reasons as text and safe links instead of injecting remote HTML.
 - Parse Markdown autolinks such as `<https://rentry.co/...>` as FMHY resources and map them to their guide sections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserved Codeberg owner and repository names in popup status labels.
 - Added missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo.
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Check changed tab URLs immediately so unsafe-page warnings appear before page completion.
 - Require real URL and hostname boundaries when matching filter-list entries.
 - Render unsafe reasons as text and safe links instead of injecting remote HTML.
 - Parse Markdown autolinks such as `<https://rentry.co/...>` as FMHY resources and map them to their guide sections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v1.3.8 (07/12/2026)
 
 #### **🔧 Enhancements**
 - Checked every changed tab URL immediately so status and toolbar icons update before page completion, with earlier warning redirects for unsafe sites.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Corrected the RIPS invite code to `1hack` while keeping EE3 on `mpgh`.
 - Added path-aware unsafe reasons for repository and link-aggregator resources.
 - Replaced the branded popup icon with a neutral status icon when a site is not listed in FMHY.
+- Made starred and safe matching resource-aware so shared hosts and sibling repositories cannot inherit each other's status.
 
 ## v1.3.7 (07/10/2026)
 

--- a/RELEASE.HEAD.md
+++ b/RELEASE.HEAD.md
@@ -1,6 +1,6 @@
-[Commits to master since this release](https://github.com/kenhendricks00/FMHY-SafeGuard/compare/v1.3.7...master)
+[Commits to main since this release](https://github.com/fmhy/FMHY-SafeGuard/compare/v1.3.8...main)
 
 To install the developer build:
 
-- **Firefox**: Click [FMHY-SafeGuard_v1.3.7.firefox.signed.xpi](https://github.com/kenhendricks00/FMHY-SafeGuard/releases/download/v1.3.7/FMHY-SafeGuard_v1.3.7.firefox.signed.xpi).
-- **Chromium**: Click [FMHY-SafeGuard_v1.3.7.chromium.zip](https://github.com/kenhendricks00/FMHY-SafeGuard/releases/download/v1.3.7/FMHY-SafeGuard_v1.3.7.chromium.zip).
+- **Firefox**: Click [FMHY-SafeGuard_v1.3.8.firefox.signed.xpi](https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.8/FMHY-SafeGuard_v1.3.8.firefox.signed.xpi).
+- **Chromium**: Click [FMHY-SafeGuard_v1.3.8.chromium.zip](https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.8/FMHY-SafeGuard_v1.3.8.chromium.zip).

--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -17,6 +17,7 @@
     "permissions": [
         "storage",
         "tabs",
+        "webNavigation",
         "alarms",
         "contextMenus"
     ],

--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -17,7 +17,6 @@
     "permissions": [
         "storage",
         "tabs",
-        "webNavigation",
         "alarms",
         "contextMenus"
     ],

--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_extensionName__",
     "default_locale": "en",
     "author": "Kenneth Hendricks & contributors",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "icons": {
         "128": "res/ext_icon_144.png"
     },

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -18,8 +18,12 @@
         "storage",
         "tabs",
         "webNavigation",
+        "webRequest",
         "alarms",
         "contextMenus"
+    ],
+    "host_permissions": [
+        "<all_urls>"
     ],
     "content_scripts": [
         {

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -17,6 +17,7 @@
     "permissions": [
         "storage",
         "tabs",
+        "webNavigation",
         "alarms",
         "contextMenus"
     ],

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -17,13 +17,8 @@
     "permissions": [
         "storage",
         "tabs",
-        "webNavigation",
-        "webRequest",
         "alarms",
         "contextMenus"
-    ],
-    "host_permissions": [
-        "<all_urls>"
     ],
     "content_scripts": [
         {

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_extensionName__",
     "default_locale": "en",
     "author": "Kenneth Hendricks & contributors",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "icons": {
         "128": "res/ext_icon_144.png"
     },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1628,6 +1628,22 @@ if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
       createdAt: Date.now(),
     });
   });
+} else if (browserAPI.webRequest?.onBeforeRedirect?.addListener) {
+  browserAPI.webRequest.onBeforeRedirect.addListener(
+    (details) => {
+      if (details.tabId < 0) return;
+      const previous = redirectOrigins.get(details.tabId);
+      const continuesChain =
+        previous &&
+        normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+      redirectOrigins.set(details.tabId, {
+        originUrl: continuesChain ? previous.originUrl : details.url,
+        targetUrl: details.redirectUrl,
+        createdAt: Date.now(),
+      });
+    },
+    { urls: ["<all_urls>"], types: ["main_frame"] }
+  );
 } else {
   browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
     if (details.frameId === 0 && details.tabId >= 0) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -746,6 +746,12 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const isEnteAuthRedirect =
+    currentHost === "auth.ente.com" &&
+    currentPath === "/login" &&
+    listedHost === "ente.com" &&
+    listedPath === "/auth";
+  if (isEnteAuthRedirect) return true;
   if (!listedPath) return !sharedHost || !currentPath;
   return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -134,6 +134,7 @@ const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
+let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -1158,6 +1159,7 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
+  if (initializationPromise) await initializationPromise;
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1338,6 +1340,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
+        if (initializationPromise) await initializationPromise;
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1901,4 +1904,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializeExtension();
+initializationPromise = initializeExtension();

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -459,22 +459,33 @@ const notesPatterns = [
 const sitePasswords = {
   "cs.rin.ru": "cs.rin.ru",
   "csrin.org": "csrin.org",
+  "steamrip.com": "steamrip.com",
   "online-fix.me": "online-fix.me",
   "ovagames.com": "www.ovagames.com",
   "g4u.to": "404",
   "elenemigos.com": "elenemigos.com",
   "triahgames.com": "www.triahgames.com",
   "soft98.ir": "soft98.ir",
+  "iptv.watchott.ru": "FREE-MEDIA",
+};
+
+// Passwords for resources that share a host and must be matched by URL.
+const siteUrlPasswords = {
+  "https://rentry.co/fmhyb64#gnarly": "gnarly",
+  "https://rentry.co/fmhyb64#alvro": "ByAlvRo",
 };
 
 // Hardcoded site invite codes - Maps domains to their invite codes
 const siteInviteCodes = {
   "ee3.me": "mpgh",
-  "rips.cc": "mpgh",
+  "rips.cc": "1hack",
 };
 
 // Get password for a domain
-function getPasswordForDomain(hostname) {
+function getPasswordForDomain(hostname, url = "") {
+  const urlPassword = siteUrlPasswords[url.toLowerCase().replace(/\/$/, "")];
+  if (urlPassword) return urlPassword;
+
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   return sitePasswords[domain] || null;
 }
@@ -1259,7 +1270,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         // Get password if available
-        const password = getPasswordForDomain(domain);
+        const password = getPasswordForDomain(domain, url);
 
         // Get invite code if available
         const inviteCode = getInviteCodeForDomain(domain);

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -539,6 +539,31 @@ async function getReasonForDomain(hostname) {
   return null;
 }
 
+function getReasonKeyForUrl(url) {
+  try {
+    const urlObj = new URL(url);
+    const domain = urlObj.hostname.replace(/^www\./, "").toLowerCase();
+    const pathname = urlObj.pathname.replace(/\/+$/, "").toLowerCase();
+    return pathname ? `${domain}${pathname}` : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+async function getReasonForUrl(url) {
+  const reasonKey = getReasonKeyForUrl(url);
+  if (!reasonKey) return null;
+
+  const hostname = new URL(url).hostname;
+  await getReasonForDomain(hostname);
+
+  const matchedKey = Object.keys(unsafeReasons)
+    .filter((key) => key.includes("/") && (reasonKey === key || reasonKey.startsWith(`${key}/`)))
+    .sort((a, b) => b.length - a.length)[0];
+
+  return matchedKey ? unsafeReasons[matchedKey] : null;
+}
+
 // Fetch note content from GitHub
 async function fetchNoteContent(noteSlug) {
   // Check cache first
@@ -1263,10 +1288,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
+        const pathSpecificReason = await getReasonForUrl(url);
+        if (status === "no_data" && pathSpecificReason) {
+          status = "unsafe";
+          matchedUrl = normalizedUrl;
+        }
+
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = await getReasonForDomain(domain);
+          reason = pathSpecificReason || await getReasonForDomain(domain);
         }
 
         // Get password if available
@@ -1469,7 +1500,7 @@ async function openWarningPage(tabId, unsafeUrl) {
   } catch (e) {
     hostname = unsafeUrl.replace(/^https?:\/\//, "").split("/")[0];
   }
-  const reason = await getReasonForDomain(hostname);
+  const reason = await getReasonForUrl(unsafeUrl) || await getReasonForDomain(hostname);
   console.log(`openWarningPage: hostname=${hostname}, reason=${reason ? "found" : "not found"}`);
 
   // Redirect to the warning page if it is enabled in settings

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1032,7 +1032,7 @@ async function notifySettingsPage() {
 }
 
 // Site Status Checking
-function checkSiteAndUpdatePageAction(tabId, url) {
+async function checkSiteAndUpdatePageAction(tabId, url) {
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1083,6 +1083,13 @@ function checkSiteAndUpdatePageAction(tabId, url) {
       status = getStatusFromLists(rootUrl + "/");
       if (status !== "no_data") matchedUrl = rootUrl + "/";
     }
+  }
+
+  // A path-specific reason can classify a resource even when it is absent from
+  // the domain filter lists. Keep the toolbar icon aligned with the popup.
+  if (status === "no_data" && await getReasonForUrl(url)) {
+    status = "unsafe";
+    matchedUrl = normalizedUrl;
   }
 
   // Apply the correct icon status to the tab

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -130,6 +130,7 @@ let starredSites = [];
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
+const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
@@ -758,6 +759,40 @@ function normalizeResourceUrl(url) {
   }
 }
 
+function getRedirectOrigin(tabId, currentUrl) {
+  if (!Number.isInteger(tabId)) return null;
+  const redirect = redirectOrigins.get(tabId);
+  if (!redirect || Date.now() - redirect.createdAt > 2 * 60 * 1000) {
+    redirectOrigins.delete(tabId);
+    return null;
+  }
+  return normalizeResourceUrl(redirect.targetUrl) === normalizeResourceUrl(currentUrl)
+    ? redirect.originUrl
+    : null;
+}
+
+function getListedResourceStatus(url) {
+  let matchedUrl = starredSites.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "starred", matchedUrl };
+
+  matchedUrl = safeSites.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "safe", matchedUrl };
+
+  matchedUrl = base64StarredLinks.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "starred", matchedUrl };
+
+  matchedUrl = base64DecodedLinks.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  return matchedUrl ? { status: "safe", matchedUrl } : null;
+}
+
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -783,6 +818,19 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const currentGreasyForkScript = currentPath.match(
+    /^\/(?:[^/]+\/)?scripts\/(\d+)/
+  );
+  const listedGreasyForkScript = listedPath.match(
+    /^\/(?:[^/]+\/)?scripts\/(\d+)/
+  );
+  if (
+    currentHost === "greasyfork.org" &&
+    listedHost === "greasyfork.org" &&
+    currentGreasyForkScript?.[1] === listedGreasyForkScript?.[1]
+  ) {
+    return true;
+  }
   const isGistPlatformPage =
     currentHost === "gist.github.com" &&
     ["/starred", "/discover"].includes(currentPath) &&
@@ -1181,6 +1229,16 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
     matchedUrl = normalizedUrl;
   }
 
+  if (status === "no_data") {
+    const redirectOrigin = getRedirectOrigin(tabId, url);
+    if (redirectOrigin) {
+      status = getStatusFromLists(normalizeResourceUrl(redirectOrigin));
+      if (status === "no_data" && await getReasonForUrl(redirectOrigin)) {
+        status = "unsafe";
+      }
+    }
+  }
+
   // Apply the correct icon status to the tab
   updatePageAction(status, tabId);
 
@@ -1352,16 +1410,35 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
-        const pathSpecificReason = await getReasonForUrl(url);
+        let reasonDomain = domain;
+        let pathSpecificReason = await getReasonForUrl(url);
         if (status === "no_data" && pathSpecificReason) {
           status = "unsafe";
           matchedUrl = normalizedUrl;
         }
 
+        if (status === "no_data") {
+          const redirectOrigin = getRedirectOrigin(message.tabId, url);
+          const redirectResourceUrl = normalizeResourceUrl(redirectOrigin);
+          if (redirectResourceUrl) {
+            status = getStatusFromLists(redirectResourceUrl);
+            const listedMatch = getListedResourceStatus(redirectResourceUrl);
+            matchedUrl = listedMatch?.matchedUrl || null;
+            reasonDomain = new URL(redirectResourceUrl).hostname;
+            pathSpecificReason = await getReasonForUrl(redirectOrigin);
+            if (status === "no_data" && pathSpecificReason) {
+              status = "unsafe";
+              matchedUrl = normalizeUrl(redirectOrigin);
+            } else if (status !== "no_data" && !matchedUrl) {
+              matchedUrl = normalizeUrl(redirectOrigin);
+            }
+          }
+        }
+
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = pathSpecificReason || await getReasonForDomain(domain);
+          reason = pathSpecificReason || await getReasonForDomain(reasonDomain);
         }
 
         // Get password if available
@@ -1533,6 +1610,19 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 // Listen for tab updates
+browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
+  if (details.frameId !== 0 || details.tabId < 0) return;
+  const previous = redirectOrigins.get(details.tabId);
+  const continuesChain =
+    previous &&
+    normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+  redirectOrigins.set(details.tabId, {
+    originUrl: continuesChain ? previous.originUrl : details.url,
+    targetUrl: details.redirectUrl,
+    createdAt: Date.now(),
+  });
+});
+
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
@@ -1558,6 +1648,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
+  redirectOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -130,12 +130,9 @@ let starredSites = [];
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
-const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
-const pendingNavigationOrigins = new Map(); // Firefox redirect fallback origins
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
-let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -761,40 +758,6 @@ function normalizeResourceUrl(url) {
   }
 }
 
-function getRedirectOrigin(tabId, currentUrl) {
-  if (!Number.isInteger(tabId)) return null;
-  const redirect = redirectOrigins.get(tabId);
-  if (!redirect || Date.now() - redirect.createdAt > 2 * 60 * 1000) {
-    redirectOrigins.delete(tabId);
-    return null;
-  }
-  return normalizeResourceUrl(redirect.targetUrl) === normalizeResourceUrl(currentUrl)
-    ? redirect.originUrl
-    : null;
-}
-
-function getListedResourceStatus(url) {
-  let matchedUrl = starredSites.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "starred", matchedUrl };
-
-  matchedUrl = safeSites.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "safe", matchedUrl };
-
-  matchedUrl = base64StarredLinks.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "starred", matchedUrl };
-
-  matchedUrl = base64DecodedLinks.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  return matchedUrl ? { status: "safe", matchedUrl } : null;
-}
-
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -1160,7 +1123,6 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
-  if (initializationPromise) await initializationPromise;
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1230,16 +1192,6 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   if (status === "no_data" && await getReasonForUrl(url)) {
     status = "unsafe";
     matchedUrl = normalizedUrl;
-  }
-
-  if (status === "no_data") {
-    const redirectOrigin = getRedirectOrigin(tabId, url);
-    if (redirectOrigin) {
-      status = getStatusFromLists(normalizeResourceUrl(redirectOrigin));
-      if (status === "no_data" && await getReasonForUrl(redirectOrigin)) {
-        status = "unsafe";
-      }
-    }
   }
 
   // Apply the correct icon status to the tab
@@ -1341,7 +1293,6 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
-        if (initializationPromise) await initializationPromise;
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1414,35 +1365,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
-        let reasonDomain = domain;
-        let pathSpecificReason = await getReasonForUrl(url);
+        const pathSpecificReason = await getReasonForUrl(url);
         if (status === "no_data" && pathSpecificReason) {
           status = "unsafe";
           matchedUrl = normalizedUrl;
         }
 
-        if (status === "no_data") {
-          const redirectOrigin = getRedirectOrigin(message.tabId, url);
-          const redirectResourceUrl = normalizeResourceUrl(redirectOrigin);
-          if (redirectResourceUrl) {
-            status = getStatusFromLists(redirectResourceUrl);
-            const listedMatch = getListedResourceStatus(redirectResourceUrl);
-            matchedUrl = listedMatch?.matchedUrl || null;
-            reasonDomain = new URL(redirectResourceUrl).hostname;
-            pathSpecificReason = await getReasonForUrl(redirectOrigin);
-            if (status === "no_data" && pathSpecificReason) {
-              status = "unsafe";
-              matchedUrl = normalizeUrl(redirectOrigin);
-            } else if (status !== "no_data" && !matchedUrl) {
-              matchedUrl = normalizeUrl(redirectOrigin);
-            }
-          }
-        }
-
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = pathSpecificReason || await getReasonForDomain(reasonDomain);
+          reason = pathSpecificReason || await getReasonForDomain(domain);
         }
 
         // Get password if available
@@ -1613,61 +1545,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
-// Track server redirects. Firefox lacks webNavigation.onBeforeRedirect, so use
-// its redirect-qualified navigation commit as a fallback.
-if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
-  browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
-    if (details.frameId !== 0 || details.tabId < 0) return;
-    const previous = redirectOrigins.get(details.tabId);
-    const continuesChain =
-      previous &&
-      normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-    redirectOrigins.set(details.tabId, {
-      originUrl: continuesChain ? previous.originUrl : details.url,
-      targetUrl: details.redirectUrl,
-      createdAt: Date.now(),
-    });
-  });
-} else if (browserAPI.webRequest?.onBeforeRedirect?.addListener) {
-  browserAPI.webRequest.onBeforeRedirect.addListener(
-    (details) => {
-      if (details.tabId < 0) return;
-      const previous = redirectOrigins.get(details.tabId);
-      const continuesChain =
-        previous &&
-        normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-      redirectOrigins.set(details.tabId, {
-        originUrl: continuesChain ? previous.originUrl : details.url,
-        targetUrl: details.redirectUrl,
-        createdAt: Date.now(),
-      });
-    },
-    { urls: ["<all_urls>"], types: ["main_frame"] }
-  );
-} else {
-  browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
-    if (details.frameId === 0 && details.tabId >= 0) {
-      pendingNavigationOrigins.set(details.tabId, details.url);
-    }
-  });
-  browserAPI.webNavigation?.onCommitted?.addListener((details) => {
-    if (details.frameId !== 0 || details.tabId < 0) return;
-    const originUrl = pendingNavigationOrigins.get(details.tabId);
-    pendingNavigationOrigins.delete(details.tabId);
-    if (
-      originUrl &&
-      details.transitionQualifiers?.includes("server_redirect") &&
-      normalizeResourceUrl(originUrl) !== normalizeResourceUrl(details.url)
-    ) {
-      redirectOrigins.set(details.tabId, {
-        originUrl,
-        targetUrl: details.url,
-        createdAt: Date.now(),
-      });
-    }
-  });
-}
-
+// Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
@@ -1693,8 +1571,6 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
-  redirectOrigins.delete(tabId);
-  pendingNavigationOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 
@@ -1947,4 +1823,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializationPromise = initializeExtension();
+initializeExtension();

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -131,6 +131,7 @@ let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
 const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
+const pendingNavigationOrigins = new Map(); // Firefox redirect fallback origins
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
@@ -1612,19 +1613,44 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
-// Listen for tab updates
-browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
-  if (details.frameId !== 0 || details.tabId < 0) return;
-  const previous = redirectOrigins.get(details.tabId);
-  const continuesChain =
-    previous &&
-    normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-  redirectOrigins.set(details.tabId, {
-    originUrl: continuesChain ? previous.originUrl : details.url,
-    targetUrl: details.redirectUrl,
-    createdAt: Date.now(),
+// Track server redirects. Firefox lacks webNavigation.onBeforeRedirect, so use
+// its redirect-qualified navigation commit as a fallback.
+if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
+  browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
+    if (details.frameId !== 0 || details.tabId < 0) return;
+    const previous = redirectOrigins.get(details.tabId);
+    const continuesChain =
+      previous &&
+      normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+    redirectOrigins.set(details.tabId, {
+      originUrl: continuesChain ? previous.originUrl : details.url,
+      targetUrl: details.redirectUrl,
+      createdAt: Date.now(),
+    });
   });
-});
+} else {
+  browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
+    if (details.frameId === 0 && details.tabId >= 0) {
+      pendingNavigationOrigins.set(details.tabId, details.url);
+    }
+  });
+  browserAPI.webNavigation?.onCommitted?.addListener((details) => {
+    if (details.frameId !== 0 || details.tabId < 0) return;
+    const originUrl = pendingNavigationOrigins.get(details.tabId);
+    pendingNavigationOrigins.delete(details.tabId);
+    if (
+      originUrl &&
+      details.transitionQualifiers?.includes("server_redirect") &&
+      normalizeResourceUrl(originUrl) !== normalizeResourceUrl(details.url)
+    ) {
+      redirectOrigins.set(details.tabId, {
+        originUrl,
+        targetUrl: details.url,
+        createdAt: Date.now(),
+      });
+    }
+  });
+}
 
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
@@ -1652,6 +1678,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
   redirectOrigins.delete(tabId);
+  pendingNavigationOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1555,9 +1555,14 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (changeInfo.url) {
+    await checkSiteAndUpdatePageAction(tabId, changeInfo.url);
+    return;
+  }
+
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
-    checkSiteAndUpdatePageAction(tabId, tab.url);
+    await checkSiteAndUpdatePageAction(tabId, tab.url);
   }
 });
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -81,7 +81,7 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
-const resourceIdentityVersion = 1;
+const resourceIdentityVersion = 2;
 const sharedResourceHosts = new Set([
   "github.com",
   "gist.github.com",
@@ -622,7 +622,7 @@ async function fetchNoteContent(noteSlug) {
   }
 }
 function extractUrlsFromMarkdown(markdown) {
-  const urlRegex = /https?:\/\/[^\s)]+/g;
+  const urlRegex = /https?:\/\/[^\s)>]+/g;
   return markdown.match(urlRegex) || [];
 }
 
@@ -669,6 +669,9 @@ function extractFmhyResourceMap(markdown, guideUrl) {
     }
 
     for (const match of line.matchAll(/\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g)) {
+      resourceMap[match[1]] = sectionUrl;
+    }
+    for (const match of line.matchAll(/<(https?:\/\/[^>\s]+)>/g)) {
       resourceMap[match[1]] = sectionUrl;
     }
   }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -1051,6 +1051,9 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
 
   const normalizedUrl = normalizeUrl(url.trim());
   const rootUrl = extractRootUrl(normalizedUrl);
+  const requiresResourcePath = normalizedUrl
+    ? isSharedResourceHost(new URL(normalizedUrl).hostname)
+    : false;
 
   // Detect if the URL is an internal extension page (settings page or warning page)
   const extUrlBase = browserAPI.runtime.getURL("");
@@ -1081,7 +1084,7 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   }
 
   // If still no match, check the root URL
-  if (status === "no_data") {
+  if (status === "no_data" && !requiresResourcePath) {
     status = getStatusFromLists(rootUrl);
     if (status !== "no_data") matchedUrl = rootUrl;
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -81,6 +81,27 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
+const sharedResourceHosts = new Set([
+  "github.com",
+  "raw.githubusercontent.com",
+  "gitlab.com",
+  "codeberg.org",
+  "sourceforge.net",
+  "rentry.co",
+  "rentry.org",
+  "pastebin.com",
+  "archive.org",
+  "drive.google.com",
+  "docs.google.com",
+  "discord.com",
+  "discord.gg",
+  "t.me",
+  "mega.nz",
+  "mediafire.com",
+  "gofile.io",
+  "pixeldrain.com",
+  "huggingface.co",
+]);
 
 // State Variables
 let unsafeSitesRegex = null;
@@ -700,6 +721,35 @@ function normalizeUrl(url) {
   }
 }
 
+function isSharedResourceHost(hostname) {
+  const domain = hostname.replace(/^www\./, "").toLowerCase();
+  for (const host of sharedResourceHosts) {
+    if (domain === host || domain.endsWith(`.${host}`)) return true;
+  }
+  return false;
+}
+
+function urlMatchesListedResource(currentUrl, listedUrl) {
+  const normalizedCurrent = normalizeUrl(currentUrl);
+  const normalizedListed = normalizeUrl(listedUrl);
+  if (!normalizedCurrent || !normalizedListed) return false;
+
+  const current = new URL(normalizedCurrent);
+  const listed = new URL(normalizedListed);
+  const currentHost = current.hostname.replace(/^www\./, "").toLowerCase();
+  const listedHost = listed.hostname.replace(/^www\./, "").toLowerCase();
+  const sharedHost = isSharedResourceHost(currentHost) || isSharedResourceHost(listedHost);
+  const hostMatches = sharedHost
+    ? currentHost === listedHost
+    : currentHost === listedHost || currentHost.endsWith(`.${listedHost}`);
+  if (!hostMatches) return false;
+
+  const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
+  const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  if (!listedPath) return !sharedHost || !currentPath;
+  return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+}
+
 function extractRootUrl(url) {
   if (!url) {
     console.warn("Received null or undefined URL for root extraction.");
@@ -1160,10 +1210,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           return;
         }
 
-        // Special handling for repository sites
-        const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-          (d) => urlObj.hostname === d || urlObj.hostname.endsWith("." + d)
-        );
+        const requiresResourcePath = isSharedResourceHost(domain);
 
         // Variables to track status and matched URL
         let status = "no_data";
@@ -1179,39 +1226,22 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         } else if (fmhySitesRegex?.test(normalizedUrl)) {
           status = "fmhy";
           matchedUrl = normalizedUrl;
-        } else if (starredSites.includes(normalizedUrl)) {
+        } else if ((matchedUrl = starredSites.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "starred";
-          matchedUrl = normalizedUrl;
-        } else if (safeSites.includes(normalizedUrl)) {
+        } else if ((matchedUrl = safeSites.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "safe";
-          matchedUrl = normalizedUrl;
-        } else if (base64StarredLinks.some(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl))) {
+        } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "starred";
-          matchedUrl = normalizedUrl;
-        } else if (base64DecodedLinks.some(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl))) {
+        } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "safe";
-          matchedUrl = normalizedUrl;
         }
 
-        // If no match for full URL and it's a repository site, check Base64 links then return
-        if (status === "no_data" && isRepoSite) {
-          const base64StarredMatch = base64StarredLinks.find(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl));
-          if (base64StarredMatch) {
-            sendResponse({ status: "starred", matchedUrl: base64StarredMatch });
-            return;
-          }
-          const base64Match = base64DecodedLinks.find(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl));
-          if (base64Match) {
-            sendResponse({ status: "safe", matchedUrl: base64Match });
-            return;
-          }
-          console.log(`No match for repository URL: ${normalizedUrl}`);
-          sendResponse({ status: "no_data", matchedUrl: normalizedUrl });
-          return;
-        }
-
-        // If no match for full URL and it's a regular site, try domain-level matching
-        if (status === "no_data" && !isRepoSite) {
+        // Shared hosts require a matching resource path; normal sites can use domain rules.
+        if (status === "no_data" && !requiresResourcePath) {
           console.log(`No match for full URL, trying domain: ${domain}`);
 
           // Check domain against regex patterns (use hostname-only regex for domain matching)
@@ -1222,69 +1252,6 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           } else if (potentiallyUnsafeHostnamesRegex?.test(domain)) {
             status = "potentially_unsafe";
             matchedUrl = `https://${domain}`;
-          }
-
-          // Check domain against starred and safe lists
-          if (status === "no_data") {
-            for (const starredUrl of starredSites) {
-              try {
-                const starredUrlObj = new URL(starredUrl);
-                if (starredUrlObj.hostname === domain) {
-                  status = "starred";
-                  matchedUrl = starredUrl;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          if (status === "no_data") {
-            for (const safeUrl of safeSites) {
-              try {
-                const safeUrlObj = new URL(safeUrl);
-                if (safeUrlObj.hostname === domain) {
-                  status = "safe";
-                  matchedUrl = safeUrl;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          // Check Base64 starred links by domain first
-          if (status === "no_data") {
-            for (const b64Url of base64StarredLinks) {
-              try {
-                const b64UrlObj = new URL(b64Url);
-                if (b64UrlObj.hostname === domain) {
-                  status = "starred";
-                  matchedUrl = b64Url;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          // Check Base64 decoded links by domain
-          if (status === "no_data") {
-            for (const b64Url of base64DecodedLinks) {
-              try {
-                const b64UrlObj = new URL(b64Url);
-                if (b64UrlObj.hostname === domain) {
-                  status = "safe";
-                  matchedUrl = b64Url;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
           }
         }
 
@@ -1389,78 +1356,22 @@ function getStatusFromLists(url) {
     if (userUntrustedDomains.has(normalizedDomain)) {
       return "unsafe";
     }
-    const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-      (domain) =>
-        urlObj.hostname === domain || urlObj.hostname.endsWith("." + domain)
-    );
+    const requiresResourcePath = isSharedResourceHost(domain);
 
-    // For repository sites, need exact path matching
-    if (isRepoSite) {
-      // Check unsafe and potentially unsafe first
-      if (unsafeSitesRegex?.test(url)) return "unsafe";
-      if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
-      if (fmhySitesRegex?.test(url)) return "fmhy";
-      if (starredSites.includes(url)) return "starred";
-      if (safeSites.includes(url)) return "safe";
-      // Check Base64 starred links first, then safe links (exact URL match for repos)
-      if (base64StarredLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "starred";
-      if (base64DecodedLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "safe";
-      return "no_data"; // No domain-only matches for repos
-    }
-
-    // For normal sites, direct checks first (full URL)
     if (unsafeSitesRegex?.test(url)) return "unsafe";
     if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
     if (fmhySitesRegex?.test(url)) return "fmhy";
-    if (starredSites.includes(url)) return "starred";
-    if (safeSites.includes(url)) return "safe";
-    // Check Base64 starred links first, then safe links
-    if (base64StarredLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "starred";
-    if (base64DecodedLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "safe";
+    if (starredSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
+    if (safeSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+    if (base64StarredLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
+    if (base64DecodedLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+
+    if (requiresResourcePath) return "no_data";
 
     // Then check domain-level (use hostname-only regex for domain matching)
     // Note: FMHY sites only match exact URLs, not domain-level
     if (unsafeHostnamesRegex?.test(domain)) return "unsafe";
     if (potentiallyUnsafeHostnamesRegex?.test(domain)) return "potentially_unsafe";
-
-    // Try domain-level checks for starred and safe
-    for (const starredUrl of starredSites) {
-      try {
-        const starredUrlObj = new URL(starredUrl);
-        if (starredUrlObj.hostname === domain) return "starred";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    for (const safeUrl of safeSites) {
-      try {
-        const safeUrlObj = new URL(safeUrl);
-        if (safeUrlObj.hostname === domain) return "safe";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    // Check Base64 starred links by domain first
-    for (const b64Url of base64StarredLinks) {
-      try {
-        const b64UrlObj = new URL(b64Url);
-        if (b64UrlObj.hostname === domain) return "starred";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    // Check Base64 decoded links by domain
-    for (const b64Url of base64DecodedLinks) {
-      try {
-        const b64UrlObj = new URL(b64Url);
-        if (b64UrlObj.hostname === domain) return "safe";
-      } catch (e) {
-        continue;
-      }
-    }
 
     return "no_data";
   } catch (e) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -81,10 +81,23 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
+const resourceIdentityVersion = 1;
 const sharedResourceHosts = new Set([
   "github.com",
   "gist.github.com",
   "raw.githubusercontent.com",
+  "greasyfork.org",
+  "youtube.com",
+  "chromewebstore.google.com",
+  "colab.research.google.com",
+  "modrinth.com",
+  "f-droid.org",
+  "xdaforums.com",
+  "start.me",
+  "sites.google.com",
+  "matrix.to",
+  "codepen.io",
+  "vk.com",
   "gitlab.com",
   "codeberg.org",
   "sourceforge.net",
@@ -664,7 +677,7 @@ function extractFmhyResourceMap(markdown, guideUrl) {
 }
 
 function getFmhyUrlForMatch(matchedUrl) {
-  const normalizedUrl = normalizeUrl(matchedUrl);
+  const normalizedUrl = normalizeResourceUrl(matchedUrl);
   if (!normalizedUrl) return null;
   return fmhyResourceMap[normalizedUrl] || null;
 }
@@ -728,6 +741,23 @@ function normalizeUrl(url) {
   }
 }
 
+function normalizeResourceUrl(url) {
+  const normalized = normalizeUrl(url);
+  if (!normalized) return null;
+
+  try {
+    const source = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+    const sourceObj = new URL(source);
+    const normalizedObj = new URL(normalized);
+    normalizedObj.search = sourceObj.search;
+    normalizedObj.hash = sourceObj.hash;
+    return normalizedObj.href;
+  } catch (error) {
+    console.warn(`Invalid resource URL skipped: ${url} - ${error.message}`);
+    return null;
+  }
+}
+
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -737,8 +767,8 @@ function isSharedResourceHost(hostname) {
 }
 
 function urlMatchesListedResource(currentUrl, listedUrl) {
-  const normalizedCurrent = normalizeUrl(currentUrl);
-  const normalizedListed = normalizeUrl(listedUrl);
+  const normalizedCurrent = normalizeResourceUrl(currentUrl);
+  const normalizedListed = normalizeResourceUrl(listedUrl);
   if (!normalizedCurrent || !normalizedListed) return false;
 
   const current = new URL(normalizedCurrent);
@@ -765,8 +795,32 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
     listedHost === "ente.com" &&
     listedPath === "/auth";
   if (isEnteAuthRedirect) return true;
-  if (!listedPath) return !sharedHost || !currentPath;
-  return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+  const pathMatches = !listedPath
+    ? !sharedHost || !currentPath
+    : currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+  if (!pathMatches) return false;
+
+  const queryIdentifiesResource = ["youtube.com", "archive.org"].includes(
+    listedHost
+  );
+  if (queryIdentifiesResource) {
+    for (const [key, value] of listed.searchParams) {
+      if (current.searchParams.get(key) !== value) return false;
+    }
+  }
+  const fragmentIdentifiesResource = [
+    "rentry.co",
+    "rentry.org",
+    "matrix.to",
+  ].includes(listedHost);
+  if (
+    fragmentIdentifiesResource &&
+    listed.hash &&
+    current.hash.toLowerCase() !== listed.hash.toLowerCase()
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function extractRootUrl(url) {
@@ -935,7 +989,7 @@ async function fetchSafeSites() {
         const guideUrl = `https://fmhy.net/${guideName}`;
         const guideMap = extractFmhyResourceMap(markdown, guideUrl);
         for (const [resourceUrl, fmhyUrl] of Object.entries(guideMap)) {
-          const normalizedResourceUrl = normalizeUrl(resourceUrl);
+          const normalizedResourceUrl = normalizeResourceUrl(resourceUrl);
           if (normalizedResourceUrl) fmhyResourceMap[normalizedResourceUrl] = fmhyUrl;
         }
       } else {
@@ -944,13 +998,16 @@ async function fetchSafeSites() {
     }
 
     // Normalize URLs and remove duplicates
-    safeSites = [...new Set(allUrls.map((url) => normalizeUrl(url.trim())))];
+    safeSites = [
+      ...new Set(allUrls.map((url) => normalizeResourceUrl(url.trim()))),
+    ].filter((url) => url !== null);
 
     // Store safe sites for content script use
     await browserAPI.storage.local.set({
       safeSiteCount: safeSites.length,
       safeSiteList: safeSites,
       fmhyResourceMap,
+      resourceIdentityVersion,
     });
 
     console.log("Stored safe site count:", safeSites.length);
@@ -982,7 +1039,7 @@ async function fetchStarredSites() {
     starredSites = Array.from(
       new Set(
         starredUrls
-          .map((url) => normalizeUrl(url))
+          .map((url) => normalizeResourceUrl(url))
           .filter((url) => url !== null)
       )
     );
@@ -990,6 +1047,7 @@ async function fetchStarredSites() {
     await browserAPI.storage.local.set({
       starredSites,
       starredSiteCount: starredSites.length,
+      resourceIdentityVersion,
     });
 
     console.log(`Stored ${starredSites.length} starred sites`);
@@ -1062,6 +1120,7 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   }
 
   const normalizedUrl = normalizeUrl(url.trim());
+  const resourceUrl = normalizeResourceUrl(url.trim());
   const rootUrl = extractRootUrl(normalizedUrl);
   const requiresResourcePath = normalizedUrl
     ? isSharedResourceHost(new URL(normalizedUrl).hostname)
@@ -1081,16 +1140,24 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   let matchedUrl = normalizedUrl;
 
   // First check the full URL
-  status = getStatusFromLists(normalizedUrl);
+  status = getStatusFromLists(resourceUrl);
 
   // If not found, try with trailing slash
-  if (status === "no_data" && !normalizedUrl.endsWith("/")) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    !normalizedUrl.endsWith("/")
+  ) {
     status = getStatusFromLists(normalizedUrl + "/");
     if (status !== "no_data") matchedUrl = normalizedUrl + "/";
   }
 
   // If not found, try without trailing slash
-  if (status === "no_data" && normalizedUrl.endsWith("/")) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    normalizedUrl.endsWith("/")
+  ) {
     status = getStatusFromLists(normalizedUrl.slice(0, -1));
     if (status !== "no_data") matchedUrl = normalizedUrl.slice(0, -1);
   }
@@ -1224,7 +1291,8 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         // Normalize the URL
         const normalizedUrl = normalizeUrl(url);
-        if (!normalizedUrl) {
+        const resourceUrl = normalizeResourceUrl(url);
+        if (!normalizedUrl || !resourceUrl) {
           sendResponse({ status: "no_data", matchedUrl: null });
           return;
         }
@@ -1256,16 +1324,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           status = "fmhy";
           matchedUrl = normalizedUrl;
         } else if ((matchedUrl = starredSites.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "starred";
         } else if ((matchedUrl = safeSites.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "safe";
         } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "starred";
         } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "safe";
         }
 
@@ -1575,7 +1643,10 @@ async function initializeExtension() {
           "safeSiteList",
           "fmhyResourceMap",
           "unsafeReasons",
+          "resourceIdentityVersion",
         ]);
+        const hasCurrentResourceIdentity =
+          storedData.resourceIdentityVersion === resourceIdentityVersion;
 
         if (storedData.unsafeSites && storedData.unsafeSites.length > 0) {
           unsafeSitesRegex = generateRegexFromList(storedData.unsafeSites);
@@ -1622,7 +1693,11 @@ async function initializeExtension() {
         }
 
         // Load starred sites from storage
-        if (storedData.starredSites && storedData.starredSites.length > 0) {
+        if (
+          hasCurrentResourceIdentity &&
+          storedData.starredSites &&
+          storedData.starredSites.length > 0
+        ) {
           starredSites = storedData.starredSites;
           console.log(
             `Loaded ${starredSites.length} starred sites from storage`
@@ -1635,7 +1710,11 @@ async function initializeExtension() {
         fmhyResourceMap = storedData.fmhyResourceMap || {};
 
         // Load safe sites and their FMHY guide locations from storage
-        if (storedData.safeSiteList && storedData.safeSiteList.length > 0) {
+        if (
+          hasCurrentResourceIdentity &&
+          storedData.safeSiteList &&
+          storedData.safeSiteList.length > 0
+        ) {
           safeSites = storedData.safeSiteList;
           console.log(`Loaded ${safeSites.length} safe sites from storage`);
           const hasLegacyAnchors = Object.values(fmhyResourceMap).some(

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -87,6 +87,7 @@ const sharedResourceHosts = new Set([
   "gitlab.com",
   "codeberg.org",
   "sourceforge.net",
+  "linktr.ee",
   "rentry.co",
   "rentry.org",
   "pastebin.com",

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -855,10 +855,15 @@ function extractRootUrl(url) {
 }
 
 function generateRegexFromList(list) {
-  const escapedList = list.map((domain) =>
-    domain.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  );
-  return new RegExp(`(${escapedList.join("|")})`, "i");
+  if (!list.length) return /(?!)/;
+
+  const boundedPatterns = list.map((entry) => {
+    const escaped = entry.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return entry.includes("://")
+      ? `^${escaped}(?=$|[/?#])`
+      : `(?:^|\\.)${escaped}$`;
+  });
+  return new RegExp(`(?:${boundedPatterns.join("|")})`, "i");
 }
 
 function extractUrlsFromFilterList(text) {

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -83,6 +83,7 @@ const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
 const sharedResourceHosts = new Set([
   "github.com",
+  "gist.github.com",
   "raw.githubusercontent.com",
   "gitlab.com",
   "codeberg.org",
@@ -618,8 +619,13 @@ function extractStarredUrlsFromMarkdown(markdown) {
   for (const line of markdown.split("\n")) {
     if (!line.includes("⭐")) continue;
 
-    const boldSections = line.match(/\*\*.*?\*\*/g) || [];
-    for (const section of boldSections) {
+    const descriptionSeparator = line.search(/\s+-\s+/);
+    const resourceGroup =
+      descriptionSeparator === -1 ? null : line.slice(0, descriptionSeparator);
+    const sections = resourceGroup
+      ? [resourceGroup]
+      : line.match(/\*\*.*?\*\*/g) || [];
+    for (const section of sections) {
       const links = section.matchAll(/\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g);
       for (const match of links) {
         starredUrls.push(match[1]);
@@ -747,6 +753,12 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const isGistPlatformPage =
+    currentHost === "gist.github.com" &&
+    ["/starred", "/discover"].includes(currentPath) &&
+    listedHost === "gist.github.com" &&
+    !listedPath;
+  if (isGistPlatformPage) return true;
   const isEnteAuthRedirect =
     currentHost === "auth.ente.com" &&
     currentPath === "/login" &&

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -48,6 +48,19 @@ let userTrusted = new Set();
 let userUntrusted = new Set();
 let unsafeReasons = {};
 
+function setUnsafeBadgeContent(badge, reason) {
+  badge.replaceChildren();
+  const icon = document.createElement("span");
+  icon.style.cssText = "display: inline-block; font-size: 14px;";
+  icon.textContent = "⚠️";
+  badge.append(
+    icon,
+    document.createTextNode(
+      ` FMHY Unsafe Site${reason ? `: ${reason}` : ""}`,
+    ),
+  );
+}
+
 // Search engines where highlighting should be applied
 const searchEngines = [
   "google.com",
@@ -309,8 +322,7 @@ function setupObserver() {
                 const badge = document.createElement('span');
                 badge.className = 'fmhy-unsafe-badge';
                 const reason = getReasonForDomain(linkDomain);
-                const reasonText = reason ? `: ${reason}` : "";
-                badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+                setUnsafeBadgeContent(badge, reason);
                 badge.dataset.domain = linkDomain;
                 siteDiv.appendChild(badge);
               }
@@ -527,8 +539,7 @@ function addWarningBanner(link, reason = null) {
         if (!siteDiv.querySelector('.fmhy-unsafe-badge')) {
           const badge = document.createElement('span');
           badge.className = 'fmhy-unsafe-badge';
-          const reasonText = reason ? `: ${reason}` : "";
-          badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+          setUnsafeBadgeContent(badge, reason);
           siteDiv.appendChild(badge);
         }
       }
@@ -557,8 +568,7 @@ function addWarningBanner(link, reason = null) {
   });
 
   // Add the warning icon and text
-  const reasonText = reason ? `: ${reason}` : "";
-  badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+  setUnsafeBadgeContent(badge, reason);
 
   // Google-specific margin adjustment
   if (currentDomain.includes("google")) {

--- a/src/pub/index.html
+++ b/src/pub/index.html
@@ -450,7 +450,7 @@
     </button>
   </div>
   <div id="status-container">
-    <img id="status-icon" class="status-image" src="safe.png" alt="Status Icon" />
+    <img id="status-icon" class="status-image" src="../res/icons/default.png" alt="Site status" />
     <p id="status-message" data-i18n="checkingSiteStatus">Checking site status...</p>
     <a id="fmhy-resource-link" target="_blank" rel="noopener noreferrer" data-i18n="viewOnFmhy">View on FMHY →</a>
   </div>

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -287,6 +287,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
+          tabId: activeTab.id,
         });
       } catch (msgError) {
         console.warn("Message send failed, retrying...", msgError);
@@ -295,6 +296,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
+          tabId: activeTab.id,
         });
       }
 

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -287,7 +287,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
-          tabId: activeTab.id,
         });
       } catch (msgError) {
         console.warn("Message send failed, retrying...", msgError);
@@ -296,7 +295,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
-          tabId: activeTab.id,
         });
       }
 

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -27,6 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     "gitlab.com",
     "codeberg.org",
     "sourceforge.net",
+    "linktr.ee",
     "rentry.co",
     "rentry.org",
     "pastebin.com",

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -1,3 +1,7 @@
+function formatHostAndPath(urlObj) {
+  return urlObj.hostname + urlObj.pathname.replace(/\/+$/, "");
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   console.log("Popup loaded, preparing to check site status...");
 
@@ -23,6 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   ]);
   const sharedResourceHosts = new Set([
     "github.com",
+    "gist.github.com",
     "raw.githubusercontent.com",
     "gitlab.com",
     "codeberg.org",
@@ -309,18 +314,17 @@ document.addEventListener("DOMContentLoaded", async () => {
                 if (currentPathParts.length >= 2) {
                   displayUrl = `${currentUrlObj.hostname}/${currentPathParts[0]}/${currentPathParts[1]}`;
                 } else {
-                  displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+                  displayUrl = formatHostAndPath(matchedUrlObj);
                 }
               } else {
-                displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+                displayUrl = formatHostAndPath(matchedUrlObj);
               }
             }
           } else if (isSharedResourceHost) {
-            displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+            displayUrl = formatHostAndPath(matchedUrlObj);
           } else {
             // Preserve a canonical FMHY resource path without a trailing slash.
-            const matchedPath = matchedUrlObj.pathname.replace(/\/+$/, "");
-            displayUrl = matchedUrlObj.hostname + matchedPath;
+            displayUrl = formatHostAndPath(matchedUrlObj);
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);
@@ -338,10 +342,10 @@ document.addEventListener("DOMContentLoaded", async () => {
           if (pathParts.length >= 2) {
             displayUrl = `${urlObj.hostname}/${pathParts[0]}/${pathParts[1]}`;
           } else {
-            displayUrl = urlObj.hostname + urlObj.pathname;
+            displayUrl = formatHostAndPath(urlObj);
           }
         } else if (isSharedResourceHost) {
-          displayUrl = urlObj.hostname + urlObj.pathname;
+          displayUrl = formatHostAndPath(urlObj);
         } else {
           // For regular sites, just show the hostname
           displayUrl = urlObj.hostname;

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -317,8 +317,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, show the hostname currently being visited
-            displayUrl = currentUrlObj.hostname;
+            // For regular sites, just show the hostname from the matched URL
+            displayUrl = matchedUrlObj.hostname;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -462,12 +462,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       starred: "../res/icons/starred.png",
       browser_page: "../res/ext_icon_144.png",
       extension_page: "../res/ext_icon_144.png",
-      no_data: "../res/ext_icon_144.png",
+      no_data: "../res/icons/default.png",
       error: "../res/icons/error.png",
-      unknown: "../res/ext_icon_144.png",
+      unknown: "../res/icons/default.png",
     };
 
     statusIcon.src = icons[status] || icons["unknown"];
+    statusIcon.alt = status === "no_data" ? "Not listed in FMHY" : "Site status";
     statusMessage.innerHTML = message || "An unknown error occurred.";
 
     statusIcon.classList.add("active");

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -21,6 +21,27 @@ document.addEventListener("DOMContentLoaded", async () => {
     "codeberg.org",
     "sourceforge.net",
   ]);
+  const sharedResourceHosts = new Set([
+    "github.com",
+    "raw.githubusercontent.com",
+    "gitlab.com",
+    "codeberg.org",
+    "sourceforge.net",
+    "rentry.co",
+    "rentry.org",
+    "pastebin.com",
+    "archive.org",
+    "drive.google.com",
+    "docs.google.com",
+    "discord.com",
+    "discord.gg",
+    "t.me",
+    "mega.nz",
+    "mediafire.com",
+    "gofile.io",
+    "pixeldrain.com",
+    "huggingface.co",
+  ]);
   let fmhyLinkContext = null;
 
   fmhyResourceLink.addEventListener("click", async (event) => {
@@ -268,6 +289,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           const matchedUrlObj = new URL(response.matchedUrl);
           const currentUrlObj = new URL(currentUrl);
           const isRepoSite = repositoryHosts.has(matchedUrlObj.hostname);
+          const isSharedResourceHost = sharedResourceHosts.has(matchedUrlObj.hostname);
 
           if (isRepoSite) {
             // For repo sites, extract the domain and path parts that were matched
@@ -292,6 +314,8 @@ document.addEventListener("DOMContentLoaded", async () => {
                 displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
               }
             }
+          } else if (isSharedResourceHost) {
+            displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
             // For regular sites, just show the hostname from the matched URL
             displayUrl = matchedUrlObj.hostname;
@@ -304,6 +328,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         // Fallback to current URL if no match
         const urlObj = new URL(currentUrl);
         const isRepoSite = repositoryHosts.has(urlObj.hostname);
+        const isSharedResourceHost = sharedResourceHosts.has(urlObj.hostname);
 
         if (isRepoSite) {
           // For repo sites, extract the domain and first two path segments (user/repo)
@@ -313,6 +338,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else {
             displayUrl = urlObj.hostname + urlObj.pathname;
           }
+        } else if (isSharedResourceHost) {
+          displayUrl = urlObj.hostname + urlObj.pathname;
         } else {
           // For regular sites, just show the hostname
           displayUrl = urlObj.hostname;

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -15,6 +15,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   const warningPageUrl = browserAPI.runtime.getURL("pub/warning-page.html");
   const settingsPageUrl = browserAPI.runtime.getURL("pub/settings-page.html");
   const welcomePageUrl = browserAPI.runtime.getURL("pub/welcome-page.html");
+  const repositoryHosts = new Set([
+    "github.com",
+    "gitlab.com",
+    "codeberg.org",
+    "sourceforge.net",
+  ]);
   let fmhyLinkContext = null;
 
   fmhyResourceLink.addEventListener("click", async (event) => {
@@ -261,15 +267,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         try {
           const matchedUrlObj = new URL(response.matchedUrl);
           const currentUrlObj = new URL(currentUrl);
-          const isRepoSite = [
-            "github.com",
-            "gitlab.com",
-            "sourceforge.net",
-          ].some(
-            (domain) =>
-              matchedUrlObj.hostname === domain ||
-              matchedUrlObj.hostname.endsWith("." + domain)
-          );
+          const isRepoSite = repositoryHosts.has(matchedUrlObj.hostname);
 
           if (isRepoSite) {
             // For repo sites, extract the domain and path parts that were matched
@@ -305,10 +303,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       } else {
         // Fallback to current URL if no match
         const urlObj = new URL(currentUrl);
-        const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-          (domain) =>
-            urlObj.hostname === domain || urlObj.hostname.endsWith("." + domain)
-        );
+        const isRepoSite = repositoryHosts.has(urlObj.hostname);
 
         if (isRepoSite) {
           // For repo sites, extract the domain and first two path segments (user/repo)

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -7,6 +7,26 @@ function formatHostAndPath(urlObj) {
   );
 }
 
+function renderTextWithLinks(container, text) {
+  container.replaceChildren();
+  const urlRegex = /https?:\/\/[^\s]+/g;
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(urlRegex)) {
+    container.append(document.createTextNode(text.slice(lastIndex, match.index)));
+    const url = match[0];
+    const link = document.createElement("a");
+    link.href = url;
+    link.textContent = url;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    container.append(link);
+    lastIndex = match.index + url.length;
+  }
+
+  container.append(document.createTextNode(text.slice(lastIndex)));
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   console.log("Popup loaded, preparing to check site status...");
 
@@ -401,10 +421,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // Handle reason display in dedicated container
     if (reason && (status === "unsafe" || status === "potentially_unsafe")) {
-      // Convert URLs to clickable links
-      const urlRegex = /(https?:\/\/[^\s]+)/g;
-      const formattedReason = reason.replace(urlRegex, '<a href="$1" target="_blank">$1</a>');
-      reasonContent.innerHTML = formattedReason;
+      renderTextWithLinks(reasonContent, reason);
       reasonContainer.classList.add("visible");
     } else {
       reasonContainer.classList.remove("visible");

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -317,8 +317,9 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, just show the hostname from the matched URL
-            displayUrl = matchedUrlObj.hostname;
+            // Preserve a canonical FMHY resource path without a trailing slash.
+            const matchedPath = matchedUrlObj.pathname.replace(/\/+$/, "");
+            displayUrl = matchedUrlObj.hostname + matchedPath;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -1,5 +1,10 @@
 function formatHostAndPath(urlObj) {
-  return urlObj.hostname + urlObj.pathname.replace(/\/+$/, "");
+  return (
+    urlObj.hostname +
+    urlObj.pathname.replace(/\/+$/, "") +
+    urlObj.search +
+    urlObj.hash
+  );
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -29,6 +34,18 @@ document.addEventListener("DOMContentLoaded", async () => {
     "github.com",
     "gist.github.com",
     "raw.githubusercontent.com",
+    "greasyfork.org",
+    "youtube.com",
+    "chromewebstore.google.com",
+    "colab.research.google.com",
+    "modrinth.com",
+    "f-droid.org",
+    "xdaforums.com",
+    "start.me",
+    "sites.google.com",
+    "matrix.to",
+    "codepen.io",
+    "vk.com",
     "gitlab.com",
     "codeberg.org",
     "sourceforge.net",

--- a/src/pub/index.js
+++ b/src/pub/index.js
@@ -317,8 +317,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, just show the hostname from the matched URL
-            displayUrl = matchedUrlObj.hostname;
+            // For regular sites, show the hostname currently being visited
+            displayUrl = currentUrlObj.hostname;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/src/pub/warning-page.js
+++ b/src/pub/warning-page.js
@@ -11,15 +11,29 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Display reason for unsafe site - prefer URL parameter, fallback to storage
   let reason = reasonFromUrl ? decodeURIComponent(reasonFromUrl) : null;
 
-  // Helper function to convert URLs to clickable links
-  function formatReasonWithLinks(text) {
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
-    return text.replace(urlRegex, '<a href="$1" target="_blank">$1</a>');
+  function renderTextWithLinks(container, text) {
+    container.replaceChildren();
+    const urlRegex = /https?:\/\/[^\s]+/g;
+    let lastIndex = 0;
+
+    for (const match of text.matchAll(urlRegex)) {
+      container.append(document.createTextNode(text.slice(lastIndex, match.index)));
+      const url = match[0];
+      const link = document.createElement("a");
+      link.href = url;
+      link.textContent = url;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      container.append(link);
+      lastIndex = match.index + url.length;
+    }
+
+    container.append(document.createTextNode(text.slice(lastIndex)));
   }
 
   if (reason) {
     console.log("Reason provided via URL parameter");
-    document.getElementById("reasonText").innerHTML = formatReasonWithLinks(reason);
+    renderTextWithLinks(document.getElementById("reasonText"), reason);
     document.getElementById("reasonContainer").style.display = "block";
   } else {
     // Fallback: try to fetch from storage
@@ -52,7 +66,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         console.log("Found reason:", reason ? "yes" : "no");
 
         if (reason) {
-          document.getElementById("reasonText").innerHTML = formatReasonWithLinks(reason);
+          renderTextWithLinks(document.getElementById("reasonText"), reason);
           document.getElementById("reasonContainer").style.display = "block";
         }
       } else {

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -1628,6 +1628,22 @@ if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
       createdAt: Date.now(),
     });
   });
+} else if (browserAPI.webRequest?.onBeforeRedirect?.addListener) {
+  browserAPI.webRequest.onBeforeRedirect.addListener(
+    (details) => {
+      if (details.tabId < 0) return;
+      const previous = redirectOrigins.get(details.tabId);
+      const continuesChain =
+        previous &&
+        normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+      redirectOrigins.set(details.tabId, {
+        originUrl: continuesChain ? previous.originUrl : details.url,
+        targetUrl: details.redirectUrl,
+        createdAt: Date.now(),
+      });
+    },
+    { urls: ["<all_urls>"], types: ["main_frame"] }
+  );
 } else {
   browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
     if (details.frameId === 0 && details.tabId >= 0) {

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -746,6 +746,12 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const isEnteAuthRedirect =
+    currentHost === "auth.ente.com" &&
+    currentPath === "/login" &&
+    listedHost === "ente.com" &&
+    listedPath === "/auth";
+  if (isEnteAuthRedirect) return true;
   if (!listedPath) return !sharedHost || !currentPath;
   return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
 }

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -134,6 +134,7 @@ const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
+let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -1158,6 +1159,7 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
+  if (initializationPromise) await initializationPromise;
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1338,6 +1340,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
+        if (initializationPromise) await initializationPromise;
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1901,4 +1904,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializeExtension();
+initializationPromise = initializeExtension();

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -81,6 +81,27 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
+const sharedResourceHosts = new Set([
+  "github.com",
+  "raw.githubusercontent.com",
+  "gitlab.com",
+  "codeberg.org",
+  "sourceforge.net",
+  "rentry.co",
+  "rentry.org",
+  "pastebin.com",
+  "archive.org",
+  "drive.google.com",
+  "docs.google.com",
+  "discord.com",
+  "discord.gg",
+  "t.me",
+  "mega.nz",
+  "mediafire.com",
+  "gofile.io",
+  "pixeldrain.com",
+  "huggingface.co",
+]);
 
 // State Variables
 let unsafeSitesRegex = null;
@@ -700,6 +721,35 @@ function normalizeUrl(url) {
   }
 }
 
+function isSharedResourceHost(hostname) {
+  const domain = hostname.replace(/^www\./, "").toLowerCase();
+  for (const host of sharedResourceHosts) {
+    if (domain === host || domain.endsWith(`.${host}`)) return true;
+  }
+  return false;
+}
+
+function urlMatchesListedResource(currentUrl, listedUrl) {
+  const normalizedCurrent = normalizeUrl(currentUrl);
+  const normalizedListed = normalizeUrl(listedUrl);
+  if (!normalizedCurrent || !normalizedListed) return false;
+
+  const current = new URL(normalizedCurrent);
+  const listed = new URL(normalizedListed);
+  const currentHost = current.hostname.replace(/^www\./, "").toLowerCase();
+  const listedHost = listed.hostname.replace(/^www\./, "").toLowerCase();
+  const sharedHost = isSharedResourceHost(currentHost) || isSharedResourceHost(listedHost);
+  const hostMatches = sharedHost
+    ? currentHost === listedHost
+    : currentHost === listedHost || currentHost.endsWith(`.${listedHost}`);
+  if (!hostMatches) return false;
+
+  const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
+  const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  if (!listedPath) return !sharedHost || !currentPath;
+  return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+}
+
 function extractRootUrl(url) {
   if (!url) {
     console.warn("Received null or undefined URL for root extraction.");
@@ -1160,10 +1210,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           return;
         }
 
-        // Special handling for repository sites
-        const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-          (d) => urlObj.hostname === d || urlObj.hostname.endsWith("." + d)
-        );
+        const requiresResourcePath = isSharedResourceHost(domain);
 
         // Variables to track status and matched URL
         let status = "no_data";
@@ -1179,39 +1226,22 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         } else if (fmhySitesRegex?.test(normalizedUrl)) {
           status = "fmhy";
           matchedUrl = normalizedUrl;
-        } else if (starredSites.includes(normalizedUrl)) {
+        } else if ((matchedUrl = starredSites.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "starred";
-          matchedUrl = normalizedUrl;
-        } else if (safeSites.includes(normalizedUrl)) {
+        } else if ((matchedUrl = safeSites.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "safe";
-          matchedUrl = normalizedUrl;
-        } else if (base64StarredLinks.some(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl))) {
+        } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "starred";
-          matchedUrl = normalizedUrl;
-        } else if (base64DecodedLinks.some(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl))) {
+        } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "safe";
-          matchedUrl = normalizedUrl;
         }
 
-        // If no match for full URL and it's a repository site, check Base64 links then return
-        if (status === "no_data" && isRepoSite) {
-          const base64StarredMatch = base64StarredLinks.find(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl));
-          if (base64StarredMatch) {
-            sendResponse({ status: "starred", matchedUrl: base64StarredMatch });
-            return;
-          }
-          const base64Match = base64DecodedLinks.find(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl));
-          if (base64Match) {
-            sendResponse({ status: "safe", matchedUrl: base64Match });
-            return;
-          }
-          console.log(`No match for repository URL: ${normalizedUrl}`);
-          sendResponse({ status: "no_data", matchedUrl: normalizedUrl });
-          return;
-        }
-
-        // If no match for full URL and it's a regular site, try domain-level matching
-        if (status === "no_data" && !isRepoSite) {
+        // Shared hosts require a matching resource path; normal sites can use domain rules.
+        if (status === "no_data" && !requiresResourcePath) {
           console.log(`No match for full URL, trying domain: ${domain}`);
 
           // Check domain against regex patterns (use hostname-only regex for domain matching)
@@ -1222,69 +1252,6 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           } else if (potentiallyUnsafeHostnamesRegex?.test(domain)) {
             status = "potentially_unsafe";
             matchedUrl = `https://${domain}`;
-          }
-
-          // Check domain against starred and safe lists
-          if (status === "no_data") {
-            for (const starredUrl of starredSites) {
-              try {
-                const starredUrlObj = new URL(starredUrl);
-                if (starredUrlObj.hostname === domain) {
-                  status = "starred";
-                  matchedUrl = starredUrl;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          if (status === "no_data") {
-            for (const safeUrl of safeSites) {
-              try {
-                const safeUrlObj = new URL(safeUrl);
-                if (safeUrlObj.hostname === domain) {
-                  status = "safe";
-                  matchedUrl = safeUrl;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          // Check Base64 starred links by domain first
-          if (status === "no_data") {
-            for (const b64Url of base64StarredLinks) {
-              try {
-                const b64UrlObj = new URL(b64Url);
-                if (b64UrlObj.hostname === domain) {
-                  status = "starred";
-                  matchedUrl = b64Url;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          // Check Base64 decoded links by domain
-          if (status === "no_data") {
-            for (const b64Url of base64DecodedLinks) {
-              try {
-                const b64UrlObj = new URL(b64Url);
-                if (b64UrlObj.hostname === domain) {
-                  status = "safe";
-                  matchedUrl = b64Url;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
           }
         }
 
@@ -1389,78 +1356,22 @@ function getStatusFromLists(url) {
     if (userUntrustedDomains.has(normalizedDomain)) {
       return "unsafe";
     }
-    const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-      (domain) =>
-        urlObj.hostname === domain || urlObj.hostname.endsWith("." + domain)
-    );
+    const requiresResourcePath = isSharedResourceHost(domain);
 
-    // For repository sites, need exact path matching
-    if (isRepoSite) {
-      // Check unsafe and potentially unsafe first
-      if (unsafeSitesRegex?.test(url)) return "unsafe";
-      if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
-      if (fmhySitesRegex?.test(url)) return "fmhy";
-      if (starredSites.includes(url)) return "starred";
-      if (safeSites.includes(url)) return "safe";
-      // Check Base64 starred links first, then safe links (exact URL match for repos)
-      if (base64StarredLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "starred";
-      if (base64DecodedLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "safe";
-      return "no_data"; // No domain-only matches for repos
-    }
-
-    // For normal sites, direct checks first (full URL)
     if (unsafeSitesRegex?.test(url)) return "unsafe";
     if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
     if (fmhySitesRegex?.test(url)) return "fmhy";
-    if (starredSites.includes(url)) return "starred";
-    if (safeSites.includes(url)) return "safe";
-    // Check Base64 starred links first, then safe links
-    if (base64StarredLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "starred";
-    if (base64DecodedLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "safe";
+    if (starredSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
+    if (safeSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+    if (base64StarredLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
+    if (base64DecodedLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+
+    if (requiresResourcePath) return "no_data";
 
     // Then check domain-level (use hostname-only regex for domain matching)
     // Note: FMHY sites only match exact URLs, not domain-level
     if (unsafeHostnamesRegex?.test(domain)) return "unsafe";
     if (potentiallyUnsafeHostnamesRegex?.test(domain)) return "potentially_unsafe";
-
-    // Try domain-level checks for starred and safe
-    for (const starredUrl of starredSites) {
-      try {
-        const starredUrlObj = new URL(starredUrl);
-        if (starredUrlObj.hostname === domain) return "starred";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    for (const safeUrl of safeSites) {
-      try {
-        const safeUrlObj = new URL(safeUrl);
-        if (safeUrlObj.hostname === domain) return "safe";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    // Check Base64 starred links by domain first
-    for (const b64Url of base64StarredLinks) {
-      try {
-        const b64UrlObj = new URL(b64Url);
-        if (b64UrlObj.hostname === domain) return "starred";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    // Check Base64 decoded links by domain
-    for (const b64Url of base64DecodedLinks) {
-      try {
-        const b64UrlObj = new URL(b64Url);
-        if (b64UrlObj.hostname === domain) return "safe";
-      } catch (e) {
-        continue;
-      }
-    }
 
     return "no_data";
   } catch (e) {
@@ -1712,9 +1623,6 @@ async function initializeExtension() {
         console.error("Error loading from storage:", error);
       }
     }
-
-    // Add fallback known sites - only for safe sites, not for starred
-    addKnownSafeSites();
 
     // Set up the update schedule
     await setupUpdateSchedule();

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -459,22 +459,33 @@ const notesPatterns = [
 const sitePasswords = {
   "cs.rin.ru": "cs.rin.ru",
   "csrin.org": "csrin.org",
+  "steamrip.com": "steamrip.com",
   "online-fix.me": "online-fix.me",
   "ovagames.com": "www.ovagames.com",
   "g4u.to": "404",
   "elenemigos.com": "elenemigos.com",
   "triahgames.com": "www.triahgames.com",
   "soft98.ir": "soft98.ir",
+  "iptv.watchott.ru": "FREE-MEDIA",
+};
+
+// Passwords for resources that share a host and must be matched by URL.
+const siteUrlPasswords = {
+  "https://rentry.co/fmhyb64#gnarly": "gnarly",
+  "https://rentry.co/fmhyb64#alvro": "ByAlvRo",
 };
 
 // Hardcoded site invite codes - Maps domains to their invite codes
 const siteInviteCodes = {
   "ee3.me": "mpgh",
-  "rips.cc": "mpgh",
+  "rips.cc": "1hack",
 };
 
 // Get password for a domain
-function getPasswordForDomain(hostname) {
+function getPasswordForDomain(hostname, url = "") {
+  const urlPassword = siteUrlPasswords[url.toLowerCase().replace(/\/$/, "")];
+  if (urlPassword) return urlPassword;
+
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   return sitePasswords[domain] || null;
 }
@@ -1259,7 +1270,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         // Get password if available
-        const password = getPasswordForDomain(domain);
+        const password = getPasswordForDomain(domain, url);
 
         // Get invite code if available
         const inviteCode = getInviteCodeForDomain(domain);

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -539,6 +539,31 @@ async function getReasonForDomain(hostname) {
   return null;
 }
 
+function getReasonKeyForUrl(url) {
+  try {
+    const urlObj = new URL(url);
+    const domain = urlObj.hostname.replace(/^www\./, "").toLowerCase();
+    const pathname = urlObj.pathname.replace(/\/+$/, "").toLowerCase();
+    return pathname ? `${domain}${pathname}` : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+async function getReasonForUrl(url) {
+  const reasonKey = getReasonKeyForUrl(url);
+  if (!reasonKey) return null;
+
+  const hostname = new URL(url).hostname;
+  await getReasonForDomain(hostname);
+
+  const matchedKey = Object.keys(unsafeReasons)
+    .filter((key) => key.includes("/") && (reasonKey === key || reasonKey.startsWith(`${key}/`)))
+    .sort((a, b) => b.length - a.length)[0];
+
+  return matchedKey ? unsafeReasons[matchedKey] : null;
+}
+
 // Fetch note content from GitHub
 async function fetchNoteContent(noteSlug) {
   // Check cache first
@@ -1263,10 +1288,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
+        const pathSpecificReason = await getReasonForUrl(url);
+        if (status === "no_data" && pathSpecificReason) {
+          status = "unsafe";
+          matchedUrl = normalizedUrl;
+        }
+
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = await getReasonForDomain(domain);
+          reason = pathSpecificReason || await getReasonForDomain(domain);
         }
 
         // Get password if available
@@ -1469,7 +1500,7 @@ async function openWarningPage(tabId, unsafeUrl) {
   } catch (e) {
     hostname = unsafeUrl.replace(/^https?:\/\//, "").split("/")[0];
   }
-  const reason = await getReasonForDomain(hostname);
+  const reason = await getReasonForUrl(unsafeUrl) || await getReasonForDomain(hostname);
   console.log(`openWarningPage: hostname=${hostname}, reason=${reason ? "found" : "not found"}`);
 
   // Redirect to the warning page if it is enabled in settings

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -1032,7 +1032,7 @@ async function notifySettingsPage() {
 }
 
 // Site Status Checking
-function checkSiteAndUpdatePageAction(tabId, url) {
+async function checkSiteAndUpdatePageAction(tabId, url) {
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1083,6 +1083,13 @@ function checkSiteAndUpdatePageAction(tabId, url) {
       status = getStatusFromLists(rootUrl + "/");
       if (status !== "no_data") matchedUrl = rootUrl + "/";
     }
+  }
+
+  // A path-specific reason can classify a resource even when it is absent from
+  // the domain filter lists. Keep the toolbar icon aligned with the popup.
+  if (status === "no_data" && await getReasonForUrl(url)) {
+    status = "unsafe";
+    matchedUrl = normalizedUrl;
   }
 
   // Apply the correct icon status to the tab

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -130,6 +130,7 @@ let starredSites = [];
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
+const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
@@ -758,6 +759,40 @@ function normalizeResourceUrl(url) {
   }
 }
 
+function getRedirectOrigin(tabId, currentUrl) {
+  if (!Number.isInteger(tabId)) return null;
+  const redirect = redirectOrigins.get(tabId);
+  if (!redirect || Date.now() - redirect.createdAt > 2 * 60 * 1000) {
+    redirectOrigins.delete(tabId);
+    return null;
+  }
+  return normalizeResourceUrl(redirect.targetUrl) === normalizeResourceUrl(currentUrl)
+    ? redirect.originUrl
+    : null;
+}
+
+function getListedResourceStatus(url) {
+  let matchedUrl = starredSites.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "starred", matchedUrl };
+
+  matchedUrl = safeSites.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "safe", matchedUrl };
+
+  matchedUrl = base64StarredLinks.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "starred", matchedUrl };
+
+  matchedUrl = base64DecodedLinks.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  return matchedUrl ? { status: "safe", matchedUrl } : null;
+}
+
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -783,6 +818,19 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const currentGreasyForkScript = currentPath.match(
+    /^\/(?:[^/]+\/)?scripts\/(\d+)/
+  );
+  const listedGreasyForkScript = listedPath.match(
+    /^\/(?:[^/]+\/)?scripts\/(\d+)/
+  );
+  if (
+    currentHost === "greasyfork.org" &&
+    listedHost === "greasyfork.org" &&
+    currentGreasyForkScript?.[1] === listedGreasyForkScript?.[1]
+  ) {
+    return true;
+  }
   const isGistPlatformPage =
     currentHost === "gist.github.com" &&
     ["/starred", "/discover"].includes(currentPath) &&
@@ -1181,6 +1229,16 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
     matchedUrl = normalizedUrl;
   }
 
+  if (status === "no_data") {
+    const redirectOrigin = getRedirectOrigin(tabId, url);
+    if (redirectOrigin) {
+      status = getStatusFromLists(normalizeResourceUrl(redirectOrigin));
+      if (status === "no_data" && await getReasonForUrl(redirectOrigin)) {
+        status = "unsafe";
+      }
+    }
+  }
+
   // Apply the correct icon status to the tab
   updatePageAction(status, tabId);
 
@@ -1352,16 +1410,35 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
-        const pathSpecificReason = await getReasonForUrl(url);
+        let reasonDomain = domain;
+        let pathSpecificReason = await getReasonForUrl(url);
         if (status === "no_data" && pathSpecificReason) {
           status = "unsafe";
           matchedUrl = normalizedUrl;
         }
 
+        if (status === "no_data") {
+          const redirectOrigin = getRedirectOrigin(message.tabId, url);
+          const redirectResourceUrl = normalizeResourceUrl(redirectOrigin);
+          if (redirectResourceUrl) {
+            status = getStatusFromLists(redirectResourceUrl);
+            const listedMatch = getListedResourceStatus(redirectResourceUrl);
+            matchedUrl = listedMatch?.matchedUrl || null;
+            reasonDomain = new URL(redirectResourceUrl).hostname;
+            pathSpecificReason = await getReasonForUrl(redirectOrigin);
+            if (status === "no_data" && pathSpecificReason) {
+              status = "unsafe";
+              matchedUrl = normalizeUrl(redirectOrigin);
+            } else if (status !== "no_data" && !matchedUrl) {
+              matchedUrl = normalizeUrl(redirectOrigin);
+            }
+          }
+        }
+
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = pathSpecificReason || await getReasonForDomain(domain);
+          reason = pathSpecificReason || await getReasonForDomain(reasonDomain);
         }
 
         // Get password if available
@@ -1533,6 +1610,19 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 // Listen for tab updates
+browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
+  if (details.frameId !== 0 || details.tabId < 0) return;
+  const previous = redirectOrigins.get(details.tabId);
+  const continuesChain =
+    previous &&
+    normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+  redirectOrigins.set(details.tabId, {
+    originUrl: continuesChain ? previous.originUrl : details.url,
+    targetUrl: details.redirectUrl,
+    createdAt: Date.now(),
+  });
+});
+
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
@@ -1558,6 +1648,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
+  redirectOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -130,12 +130,9 @@ let starredSites = [];
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
-const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
-const pendingNavigationOrigins = new Map(); // Firefox redirect fallback origins
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
-let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -761,40 +758,6 @@ function normalizeResourceUrl(url) {
   }
 }
 
-function getRedirectOrigin(tabId, currentUrl) {
-  if (!Number.isInteger(tabId)) return null;
-  const redirect = redirectOrigins.get(tabId);
-  if (!redirect || Date.now() - redirect.createdAt > 2 * 60 * 1000) {
-    redirectOrigins.delete(tabId);
-    return null;
-  }
-  return normalizeResourceUrl(redirect.targetUrl) === normalizeResourceUrl(currentUrl)
-    ? redirect.originUrl
-    : null;
-}
-
-function getListedResourceStatus(url) {
-  let matchedUrl = starredSites.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "starred", matchedUrl };
-
-  matchedUrl = safeSites.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "safe", matchedUrl };
-
-  matchedUrl = base64StarredLinks.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "starred", matchedUrl };
-
-  matchedUrl = base64DecodedLinks.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  return matchedUrl ? { status: "safe", matchedUrl } : null;
-}
-
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -1160,7 +1123,6 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
-  if (initializationPromise) await initializationPromise;
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1230,16 +1192,6 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   if (status === "no_data" && await getReasonForUrl(url)) {
     status = "unsafe";
     matchedUrl = normalizedUrl;
-  }
-
-  if (status === "no_data") {
-    const redirectOrigin = getRedirectOrigin(tabId, url);
-    if (redirectOrigin) {
-      status = getStatusFromLists(normalizeResourceUrl(redirectOrigin));
-      if (status === "no_data" && await getReasonForUrl(redirectOrigin)) {
-        status = "unsafe";
-      }
-    }
   }
 
   // Apply the correct icon status to the tab
@@ -1341,7 +1293,6 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
-        if (initializationPromise) await initializationPromise;
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1414,35 +1365,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
-        let reasonDomain = domain;
-        let pathSpecificReason = await getReasonForUrl(url);
+        const pathSpecificReason = await getReasonForUrl(url);
         if (status === "no_data" && pathSpecificReason) {
           status = "unsafe";
           matchedUrl = normalizedUrl;
         }
 
-        if (status === "no_data") {
-          const redirectOrigin = getRedirectOrigin(message.tabId, url);
-          const redirectResourceUrl = normalizeResourceUrl(redirectOrigin);
-          if (redirectResourceUrl) {
-            status = getStatusFromLists(redirectResourceUrl);
-            const listedMatch = getListedResourceStatus(redirectResourceUrl);
-            matchedUrl = listedMatch?.matchedUrl || null;
-            reasonDomain = new URL(redirectResourceUrl).hostname;
-            pathSpecificReason = await getReasonForUrl(redirectOrigin);
-            if (status === "no_data" && pathSpecificReason) {
-              status = "unsafe";
-              matchedUrl = normalizeUrl(redirectOrigin);
-            } else if (status !== "no_data" && !matchedUrl) {
-              matchedUrl = normalizeUrl(redirectOrigin);
-            }
-          }
-        }
-
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = pathSpecificReason || await getReasonForDomain(reasonDomain);
+          reason = pathSpecificReason || await getReasonForDomain(domain);
         }
 
         // Get password if available
@@ -1613,61 +1545,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
-// Track server redirects. Firefox lacks webNavigation.onBeforeRedirect, so use
-// its redirect-qualified navigation commit as a fallback.
-if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
-  browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
-    if (details.frameId !== 0 || details.tabId < 0) return;
-    const previous = redirectOrigins.get(details.tabId);
-    const continuesChain =
-      previous &&
-      normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-    redirectOrigins.set(details.tabId, {
-      originUrl: continuesChain ? previous.originUrl : details.url,
-      targetUrl: details.redirectUrl,
-      createdAt: Date.now(),
-    });
-  });
-} else if (browserAPI.webRequest?.onBeforeRedirect?.addListener) {
-  browserAPI.webRequest.onBeforeRedirect.addListener(
-    (details) => {
-      if (details.tabId < 0) return;
-      const previous = redirectOrigins.get(details.tabId);
-      const continuesChain =
-        previous &&
-        normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-      redirectOrigins.set(details.tabId, {
-        originUrl: continuesChain ? previous.originUrl : details.url,
-        targetUrl: details.redirectUrl,
-        createdAt: Date.now(),
-      });
-    },
-    { urls: ["<all_urls>"], types: ["main_frame"] }
-  );
-} else {
-  browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
-    if (details.frameId === 0 && details.tabId >= 0) {
-      pendingNavigationOrigins.set(details.tabId, details.url);
-    }
-  });
-  browserAPI.webNavigation?.onCommitted?.addListener((details) => {
-    if (details.frameId !== 0 || details.tabId < 0) return;
-    const originUrl = pendingNavigationOrigins.get(details.tabId);
-    pendingNavigationOrigins.delete(details.tabId);
-    if (
-      originUrl &&
-      details.transitionQualifiers?.includes("server_redirect") &&
-      normalizeResourceUrl(originUrl) !== normalizeResourceUrl(details.url)
-    ) {
-      redirectOrigins.set(details.tabId, {
-        originUrl,
-        targetUrl: details.url,
-        createdAt: Date.now(),
-      });
-    }
-  });
-}
-
+// Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
@@ -1693,8 +1571,6 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
-  redirectOrigins.delete(tabId);
-  pendingNavigationOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 
@@ -1947,4 +1823,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializationPromise = initializeExtension();
+initializeExtension();

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -131,6 +131,7 @@ let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
 const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
+const pendingNavigationOrigins = new Map(); // Firefox redirect fallback origins
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
@@ -1612,19 +1613,44 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
-// Listen for tab updates
-browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
-  if (details.frameId !== 0 || details.tabId < 0) return;
-  const previous = redirectOrigins.get(details.tabId);
-  const continuesChain =
-    previous &&
-    normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-  redirectOrigins.set(details.tabId, {
-    originUrl: continuesChain ? previous.originUrl : details.url,
-    targetUrl: details.redirectUrl,
-    createdAt: Date.now(),
+// Track server redirects. Firefox lacks webNavigation.onBeforeRedirect, so use
+// its redirect-qualified navigation commit as a fallback.
+if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
+  browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
+    if (details.frameId !== 0 || details.tabId < 0) return;
+    const previous = redirectOrigins.get(details.tabId);
+    const continuesChain =
+      previous &&
+      normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+    redirectOrigins.set(details.tabId, {
+      originUrl: continuesChain ? previous.originUrl : details.url,
+      targetUrl: details.redirectUrl,
+      createdAt: Date.now(),
+    });
   });
-});
+} else {
+  browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
+    if (details.frameId === 0 && details.tabId >= 0) {
+      pendingNavigationOrigins.set(details.tabId, details.url);
+    }
+  });
+  browserAPI.webNavigation?.onCommitted?.addListener((details) => {
+    if (details.frameId !== 0 || details.tabId < 0) return;
+    const originUrl = pendingNavigationOrigins.get(details.tabId);
+    pendingNavigationOrigins.delete(details.tabId);
+    if (
+      originUrl &&
+      details.transitionQualifiers?.includes("server_redirect") &&
+      normalizeResourceUrl(originUrl) !== normalizeResourceUrl(details.url)
+    ) {
+      redirectOrigins.set(details.tabId, {
+        originUrl,
+        targetUrl: details.url,
+        createdAt: Date.now(),
+      });
+    }
+  });
+}
 
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
@@ -1652,6 +1678,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
   redirectOrigins.delete(tabId);
+  pendingNavigationOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -1555,9 +1555,14 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (changeInfo.url) {
+    await checkSiteAndUpdatePageAction(tabId, changeInfo.url);
+    return;
+  }
+
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
-    checkSiteAndUpdatePageAction(tabId, tab.url);
+    await checkSiteAndUpdatePageAction(tabId, tab.url);
   }
 });
 

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -81,7 +81,7 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
-const resourceIdentityVersion = 1;
+const resourceIdentityVersion = 2;
 const sharedResourceHosts = new Set([
   "github.com",
   "gist.github.com",
@@ -622,7 +622,7 @@ async function fetchNoteContent(noteSlug) {
   }
 }
 function extractUrlsFromMarkdown(markdown) {
-  const urlRegex = /https?:\/\/[^\s)]+/g;
+  const urlRegex = /https?:\/\/[^\s)>]+/g;
   return markdown.match(urlRegex) || [];
 }
 
@@ -669,6 +669,9 @@ function extractFmhyResourceMap(markdown, guideUrl) {
     }
 
     for (const match of line.matchAll(/\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g)) {
+      resourceMap[match[1]] = sectionUrl;
+    }
+    for (const match of line.matchAll(/<(https?:\/\/[^>\s]+)>/g)) {
       resourceMap[match[1]] = sectionUrl;
     }
   }

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -1051,6 +1051,9 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
 
   const normalizedUrl = normalizeUrl(url.trim());
   const rootUrl = extractRootUrl(normalizedUrl);
+  const requiresResourcePath = normalizedUrl
+    ? isSharedResourceHost(new URL(normalizedUrl).hostname)
+    : false;
 
   // Detect if the URL is an internal extension page (settings page or warning page)
   const extUrlBase = browserAPI.runtime.getURL("");
@@ -1081,7 +1084,7 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   }
 
   // If still no match, check the root URL
-  if (status === "no_data") {
+  if (status === "no_data" && !requiresResourcePath) {
     status = getStatusFromLists(rootUrl);
     if (status !== "no_data") matchedUrl = rootUrl;
 

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -81,10 +81,23 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
+const resourceIdentityVersion = 1;
 const sharedResourceHosts = new Set([
   "github.com",
   "gist.github.com",
   "raw.githubusercontent.com",
+  "greasyfork.org",
+  "youtube.com",
+  "chromewebstore.google.com",
+  "colab.research.google.com",
+  "modrinth.com",
+  "f-droid.org",
+  "xdaforums.com",
+  "start.me",
+  "sites.google.com",
+  "matrix.to",
+  "codepen.io",
+  "vk.com",
   "gitlab.com",
   "codeberg.org",
   "sourceforge.net",
@@ -664,7 +677,7 @@ function extractFmhyResourceMap(markdown, guideUrl) {
 }
 
 function getFmhyUrlForMatch(matchedUrl) {
-  const normalizedUrl = normalizeUrl(matchedUrl);
+  const normalizedUrl = normalizeResourceUrl(matchedUrl);
   if (!normalizedUrl) return null;
   return fmhyResourceMap[normalizedUrl] || null;
 }
@@ -728,6 +741,23 @@ function normalizeUrl(url) {
   }
 }
 
+function normalizeResourceUrl(url) {
+  const normalized = normalizeUrl(url);
+  if (!normalized) return null;
+
+  try {
+    const source = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+    const sourceObj = new URL(source);
+    const normalizedObj = new URL(normalized);
+    normalizedObj.search = sourceObj.search;
+    normalizedObj.hash = sourceObj.hash;
+    return normalizedObj.href;
+  } catch (error) {
+    console.warn(`Invalid resource URL skipped: ${url} - ${error.message}`);
+    return null;
+  }
+}
+
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -737,8 +767,8 @@ function isSharedResourceHost(hostname) {
 }
 
 function urlMatchesListedResource(currentUrl, listedUrl) {
-  const normalizedCurrent = normalizeUrl(currentUrl);
-  const normalizedListed = normalizeUrl(listedUrl);
+  const normalizedCurrent = normalizeResourceUrl(currentUrl);
+  const normalizedListed = normalizeResourceUrl(listedUrl);
   if (!normalizedCurrent || !normalizedListed) return false;
 
   const current = new URL(normalizedCurrent);
@@ -765,8 +795,32 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
     listedHost === "ente.com" &&
     listedPath === "/auth";
   if (isEnteAuthRedirect) return true;
-  if (!listedPath) return !sharedHost || !currentPath;
-  return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+  const pathMatches = !listedPath
+    ? !sharedHost || !currentPath
+    : currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+  if (!pathMatches) return false;
+
+  const queryIdentifiesResource = ["youtube.com", "archive.org"].includes(
+    listedHost
+  );
+  if (queryIdentifiesResource) {
+    for (const [key, value] of listed.searchParams) {
+      if (current.searchParams.get(key) !== value) return false;
+    }
+  }
+  const fragmentIdentifiesResource = [
+    "rentry.co",
+    "rentry.org",
+    "matrix.to",
+  ].includes(listedHost);
+  if (
+    fragmentIdentifiesResource &&
+    listed.hash &&
+    current.hash.toLowerCase() !== listed.hash.toLowerCase()
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function extractRootUrl(url) {
@@ -935,7 +989,7 @@ async function fetchSafeSites() {
         const guideUrl = `https://fmhy.net/${guideName}`;
         const guideMap = extractFmhyResourceMap(markdown, guideUrl);
         for (const [resourceUrl, fmhyUrl] of Object.entries(guideMap)) {
-          const normalizedResourceUrl = normalizeUrl(resourceUrl);
+          const normalizedResourceUrl = normalizeResourceUrl(resourceUrl);
           if (normalizedResourceUrl) fmhyResourceMap[normalizedResourceUrl] = fmhyUrl;
         }
       } else {
@@ -944,13 +998,16 @@ async function fetchSafeSites() {
     }
 
     // Normalize URLs and remove duplicates
-    safeSites = [...new Set(allUrls.map((url) => normalizeUrl(url.trim())))];
+    safeSites = [
+      ...new Set(allUrls.map((url) => normalizeResourceUrl(url.trim()))),
+    ].filter((url) => url !== null);
 
     // Store safe sites for content script use
     await browserAPI.storage.local.set({
       safeSiteCount: safeSites.length,
       safeSiteList: safeSites,
       fmhyResourceMap,
+      resourceIdentityVersion,
     });
 
     console.log("Stored safe site count:", safeSites.length);
@@ -982,7 +1039,7 @@ async function fetchStarredSites() {
     starredSites = Array.from(
       new Set(
         starredUrls
-          .map((url) => normalizeUrl(url))
+          .map((url) => normalizeResourceUrl(url))
           .filter((url) => url !== null)
       )
     );
@@ -990,6 +1047,7 @@ async function fetchStarredSites() {
     await browserAPI.storage.local.set({
       starredSites,
       starredSiteCount: starredSites.length,
+      resourceIdentityVersion,
     });
 
     console.log(`Stored ${starredSites.length} starred sites`);
@@ -1062,6 +1120,7 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   }
 
   const normalizedUrl = normalizeUrl(url.trim());
+  const resourceUrl = normalizeResourceUrl(url.trim());
   const rootUrl = extractRootUrl(normalizedUrl);
   const requiresResourcePath = normalizedUrl
     ? isSharedResourceHost(new URL(normalizedUrl).hostname)
@@ -1081,16 +1140,24 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   let matchedUrl = normalizedUrl;
 
   // First check the full URL
-  status = getStatusFromLists(normalizedUrl);
+  status = getStatusFromLists(resourceUrl);
 
   // If not found, try with trailing slash
-  if (status === "no_data" && !normalizedUrl.endsWith("/")) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    !normalizedUrl.endsWith("/")
+  ) {
     status = getStatusFromLists(normalizedUrl + "/");
     if (status !== "no_data") matchedUrl = normalizedUrl + "/";
   }
 
   // If not found, try without trailing slash
-  if (status === "no_data" && normalizedUrl.endsWith("/")) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    normalizedUrl.endsWith("/")
+  ) {
     status = getStatusFromLists(normalizedUrl.slice(0, -1));
     if (status !== "no_data") matchedUrl = normalizedUrl.slice(0, -1);
   }
@@ -1224,7 +1291,8 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         // Normalize the URL
         const normalizedUrl = normalizeUrl(url);
-        if (!normalizedUrl) {
+        const resourceUrl = normalizeResourceUrl(url);
+        if (!normalizedUrl || !resourceUrl) {
           sendResponse({ status: "no_data", matchedUrl: null });
           return;
         }
@@ -1256,16 +1324,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           status = "fmhy";
           matchedUrl = normalizedUrl;
         } else if ((matchedUrl = starredSites.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "starred";
         } else if ((matchedUrl = safeSites.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "safe";
         } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "starred";
         } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "safe";
         }
 
@@ -1575,7 +1643,10 @@ async function initializeExtension() {
           "safeSiteList",
           "fmhyResourceMap",
           "unsafeReasons",
+          "resourceIdentityVersion",
         ]);
+        const hasCurrentResourceIdentity =
+          storedData.resourceIdentityVersion === resourceIdentityVersion;
 
         if (storedData.unsafeSites && storedData.unsafeSites.length > 0) {
           unsafeSitesRegex = generateRegexFromList(storedData.unsafeSites);
@@ -1622,7 +1693,11 @@ async function initializeExtension() {
         }
 
         // Load starred sites from storage
-        if (storedData.starredSites && storedData.starredSites.length > 0) {
+        if (
+          hasCurrentResourceIdentity &&
+          storedData.starredSites &&
+          storedData.starredSites.length > 0
+        ) {
           starredSites = storedData.starredSites;
           console.log(
             `Loaded ${starredSites.length} starred sites from storage`
@@ -1635,7 +1710,11 @@ async function initializeExtension() {
         fmhyResourceMap = storedData.fmhyResourceMap || {};
 
         // Load safe sites and their FMHY guide locations from storage
-        if (storedData.safeSiteList && storedData.safeSiteList.length > 0) {
+        if (
+          hasCurrentResourceIdentity &&
+          storedData.safeSiteList &&
+          storedData.safeSiteList.length > 0
+        ) {
           safeSites = storedData.safeSiteList;
           console.log(`Loaded ${safeSites.length} safe sites from storage`);
           const hasLegacyAnchors = Object.values(fmhyResourceMap).some(

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -87,6 +87,7 @@ const sharedResourceHosts = new Set([
   "gitlab.com",
   "codeberg.org",
   "sourceforge.net",
+  "linktr.ee",
   "rentry.co",
   "rentry.org",
   "pastebin.com",

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -855,10 +855,15 @@ function extractRootUrl(url) {
 }
 
 function generateRegexFromList(list) {
-  const escapedList = list.map((domain) =>
-    domain.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  );
-  return new RegExp(`(${escapedList.join("|")})`, "i");
+  if (!list.length) return /(?!)/;
+
+  const boundedPatterns = list.map((entry) => {
+    const escaped = entry.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return entry.includes("://")
+      ? `^${escaped}(?=$|[/?#])`
+      : `(?:^|\\.)${escaped}$`;
+  });
+  return new RegExp(`(?:${boundedPatterns.join("|")})`, "i");
 }
 
 function extractUrlsFromFilterList(text) {

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -83,6 +83,7 @@ const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
 const sharedResourceHosts = new Set([
   "github.com",
+  "gist.github.com",
   "raw.githubusercontent.com",
   "gitlab.com",
   "codeberg.org",
@@ -618,8 +619,13 @@ function extractStarredUrlsFromMarkdown(markdown) {
   for (const line of markdown.split("\n")) {
     if (!line.includes("⭐")) continue;
 
-    const boldSections = line.match(/\*\*.*?\*\*/g) || [];
-    for (const section of boldSections) {
+    const descriptionSeparator = line.search(/\s+-\s+/);
+    const resourceGroup =
+      descriptionSeparator === -1 ? null : line.slice(0, descriptionSeparator);
+    const sections = resourceGroup
+      ? [resourceGroup]
+      : line.match(/\*\*.*?\*\*/g) || [];
+    for (const section of sections) {
       const links = section.matchAll(/\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g);
       for (const match of links) {
         starredUrls.push(match[1]);
@@ -747,6 +753,12 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const isGistPlatformPage =
+    currentHost === "gist.github.com" &&
+    ["/starred", "/discover"].includes(currentPath) &&
+    listedHost === "gist.github.com" &&
+    !listedPath;
+  if (isGistPlatformPage) return true;
   const isEnteAuthRedirect =
     currentHost === "auth.ente.com" &&
     currentPath === "/login" &&

--- a/test-builds/chrome/js/content.js
+++ b/test-builds/chrome/js/content.js
@@ -48,6 +48,19 @@ let userTrusted = new Set();
 let userUntrusted = new Set();
 let unsafeReasons = {};
 
+function setUnsafeBadgeContent(badge, reason) {
+  badge.replaceChildren();
+  const icon = document.createElement("span");
+  icon.style.cssText = "display: inline-block; font-size: 14px;";
+  icon.textContent = "⚠️";
+  badge.append(
+    icon,
+    document.createTextNode(
+      ` FMHY Unsafe Site${reason ? `: ${reason}` : ""}`,
+    ),
+  );
+}
+
 // Search engines where highlighting should be applied
 const searchEngines = [
   "google.com",
@@ -309,8 +322,7 @@ function setupObserver() {
                 const badge = document.createElement('span');
                 badge.className = 'fmhy-unsafe-badge';
                 const reason = getReasonForDomain(linkDomain);
-                const reasonText = reason ? `: ${reason}` : "";
-                badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+                setUnsafeBadgeContent(badge, reason);
                 badge.dataset.domain = linkDomain;
                 siteDiv.appendChild(badge);
               }
@@ -527,8 +539,7 @@ function addWarningBanner(link, reason = null) {
         if (!siteDiv.querySelector('.fmhy-unsafe-badge')) {
           const badge = document.createElement('span');
           badge.className = 'fmhy-unsafe-badge';
-          const reasonText = reason ? `: ${reason}` : "";
-          badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+          setUnsafeBadgeContent(badge, reason);
           siteDiv.appendChild(badge);
         }
       }
@@ -557,8 +568,7 @@ function addWarningBanner(link, reason = null) {
   });
 
   // Add the warning icon and text
-  const reasonText = reason ? `: ${reason}` : "";
-  badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+  setUnsafeBadgeContent(badge, reason);
 
   // Google-specific margin adjustment
   if (currentDomain.includes("google")) {

--- a/test-builds/chrome/manifest.json
+++ b/test-builds/chrome/manifest.json
@@ -17,6 +17,7 @@
     "permissions": [
         "storage",
         "tabs",
+        "webNavigation",
         "alarms",
         "contextMenus"
     ],

--- a/test-builds/chrome/manifest.json
+++ b/test-builds/chrome/manifest.json
@@ -17,7 +17,6 @@
     "permissions": [
         "storage",
         "tabs",
-        "webNavigation",
         "alarms",
         "contextMenus"
     ],

--- a/test-builds/chrome/manifest.json
+++ b/test-builds/chrome/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_extensionName__",
     "default_locale": "en",
     "author": "Kenneth Hendricks & contributors",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "icons": {
         "128": "res/ext_icon_144.png"
     },

--- a/test-builds/chrome/pub/index.html
+++ b/test-builds/chrome/pub/index.html
@@ -450,7 +450,7 @@
     </button>
   </div>
   <div id="status-container">
-    <img id="status-icon" class="status-image" src="safe.png" alt="Status Icon" />
+    <img id="status-icon" class="status-image" src="../res/icons/default.png" alt="Site status" />
     <p id="status-message" data-i18n="checkingSiteStatus">Checking site status...</p>
     <a id="fmhy-resource-link" target="_blank" rel="noopener noreferrer" data-i18n="viewOnFmhy">View on FMHY →</a>
   </div>

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -287,6 +287,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
+          tabId: activeTab.id,
         });
       } catch (msgError) {
         console.warn("Message send failed, retrying...", msgError);
@@ -295,6 +296,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
+          tabId: activeTab.id,
         });
       }
 

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -287,7 +287,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
-          tabId: activeTab.id,
         });
       } catch (msgError) {
         console.warn("Message send failed, retrying...", msgError);
@@ -296,7 +295,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
-          tabId: activeTab.id,
         });
       }
 

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -27,6 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     "gitlab.com",
     "codeberg.org",
     "sourceforge.net",
+    "linktr.ee",
     "rentry.co",
     "rentry.org",
     "pastebin.com",

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -1,3 +1,7 @@
+function formatHostAndPath(urlObj) {
+  return urlObj.hostname + urlObj.pathname.replace(/\/+$/, "");
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   console.log("Popup loaded, preparing to check site status...");
 
@@ -23,6 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   ]);
   const sharedResourceHosts = new Set([
     "github.com",
+    "gist.github.com",
     "raw.githubusercontent.com",
     "gitlab.com",
     "codeberg.org",
@@ -309,18 +314,17 @@ document.addEventListener("DOMContentLoaded", async () => {
                 if (currentPathParts.length >= 2) {
                   displayUrl = `${currentUrlObj.hostname}/${currentPathParts[0]}/${currentPathParts[1]}`;
                 } else {
-                  displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+                  displayUrl = formatHostAndPath(matchedUrlObj);
                 }
               } else {
-                displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+                displayUrl = formatHostAndPath(matchedUrlObj);
               }
             }
           } else if (isSharedResourceHost) {
-            displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+            displayUrl = formatHostAndPath(matchedUrlObj);
           } else {
             // Preserve a canonical FMHY resource path without a trailing slash.
-            const matchedPath = matchedUrlObj.pathname.replace(/\/+$/, "");
-            displayUrl = matchedUrlObj.hostname + matchedPath;
+            displayUrl = formatHostAndPath(matchedUrlObj);
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);
@@ -338,10 +342,10 @@ document.addEventListener("DOMContentLoaded", async () => {
           if (pathParts.length >= 2) {
             displayUrl = `${urlObj.hostname}/${pathParts[0]}/${pathParts[1]}`;
           } else {
-            displayUrl = urlObj.hostname + urlObj.pathname;
+            displayUrl = formatHostAndPath(urlObj);
           }
         } else if (isSharedResourceHost) {
-          displayUrl = urlObj.hostname + urlObj.pathname;
+          displayUrl = formatHostAndPath(urlObj);
         } else {
           // For regular sites, just show the hostname
           displayUrl = urlObj.hostname;

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -317,8 +317,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, show the hostname currently being visited
-            displayUrl = currentUrlObj.hostname;
+            // For regular sites, just show the hostname from the matched URL
+            displayUrl = matchedUrlObj.hostname;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -462,12 +462,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       starred: "../res/icons/starred.png",
       browser_page: "../res/ext_icon_144.png",
       extension_page: "../res/ext_icon_144.png",
-      no_data: "../res/ext_icon_144.png",
+      no_data: "../res/icons/default.png",
       error: "../res/icons/error.png",
-      unknown: "../res/ext_icon_144.png",
+      unknown: "../res/icons/default.png",
     };
 
     statusIcon.src = icons[status] || icons["unknown"];
+    statusIcon.alt = status === "no_data" ? "Not listed in FMHY" : "Site status";
     statusMessage.innerHTML = message || "An unknown error occurred.";
 
     statusIcon.classList.add("active");

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -21,6 +21,27 @@ document.addEventListener("DOMContentLoaded", async () => {
     "codeberg.org",
     "sourceforge.net",
   ]);
+  const sharedResourceHosts = new Set([
+    "github.com",
+    "raw.githubusercontent.com",
+    "gitlab.com",
+    "codeberg.org",
+    "sourceforge.net",
+    "rentry.co",
+    "rentry.org",
+    "pastebin.com",
+    "archive.org",
+    "drive.google.com",
+    "docs.google.com",
+    "discord.com",
+    "discord.gg",
+    "t.me",
+    "mega.nz",
+    "mediafire.com",
+    "gofile.io",
+    "pixeldrain.com",
+    "huggingface.co",
+  ]);
   let fmhyLinkContext = null;
 
   fmhyResourceLink.addEventListener("click", async (event) => {
@@ -268,6 +289,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           const matchedUrlObj = new URL(response.matchedUrl);
           const currentUrlObj = new URL(currentUrl);
           const isRepoSite = repositoryHosts.has(matchedUrlObj.hostname);
+          const isSharedResourceHost = sharedResourceHosts.has(matchedUrlObj.hostname);
 
           if (isRepoSite) {
             // For repo sites, extract the domain and path parts that were matched
@@ -292,6 +314,8 @@ document.addEventListener("DOMContentLoaded", async () => {
                 displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
               }
             }
+          } else if (isSharedResourceHost) {
+            displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
             // For regular sites, just show the hostname from the matched URL
             displayUrl = matchedUrlObj.hostname;
@@ -304,6 +328,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         // Fallback to current URL if no match
         const urlObj = new URL(currentUrl);
         const isRepoSite = repositoryHosts.has(urlObj.hostname);
+        const isSharedResourceHost = sharedResourceHosts.has(urlObj.hostname);
 
         if (isRepoSite) {
           // For repo sites, extract the domain and first two path segments (user/repo)
@@ -313,6 +338,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else {
             displayUrl = urlObj.hostname + urlObj.pathname;
           }
+        } else if (isSharedResourceHost) {
+          displayUrl = urlObj.hostname + urlObj.pathname;
         } else {
           // For regular sites, just show the hostname
           displayUrl = urlObj.hostname;

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -15,6 +15,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   const warningPageUrl = browserAPI.runtime.getURL("pub/warning-page.html");
   const settingsPageUrl = browserAPI.runtime.getURL("pub/settings-page.html");
   const welcomePageUrl = browserAPI.runtime.getURL("pub/welcome-page.html");
+  const repositoryHosts = new Set([
+    "github.com",
+    "gitlab.com",
+    "codeberg.org",
+    "sourceforge.net",
+  ]);
   let fmhyLinkContext = null;
 
   fmhyResourceLink.addEventListener("click", async (event) => {
@@ -261,15 +267,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         try {
           const matchedUrlObj = new URL(response.matchedUrl);
           const currentUrlObj = new URL(currentUrl);
-          const isRepoSite = [
-            "github.com",
-            "gitlab.com",
-            "sourceforge.net",
-          ].some(
-            (domain) =>
-              matchedUrlObj.hostname === domain ||
-              matchedUrlObj.hostname.endsWith("." + domain)
-          );
+          const isRepoSite = repositoryHosts.has(matchedUrlObj.hostname);
 
           if (isRepoSite) {
             // For repo sites, extract the domain and path parts that were matched
@@ -305,10 +303,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       } else {
         // Fallback to current URL if no match
         const urlObj = new URL(currentUrl);
-        const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-          (domain) =>
-            urlObj.hostname === domain || urlObj.hostname.endsWith("." + domain)
-        );
+        const isRepoSite = repositoryHosts.has(urlObj.hostname);
 
         if (isRepoSite) {
           // For repo sites, extract the domain and first two path segments (user/repo)

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -7,6 +7,26 @@ function formatHostAndPath(urlObj) {
   );
 }
 
+function renderTextWithLinks(container, text) {
+  container.replaceChildren();
+  const urlRegex = /https?:\/\/[^\s]+/g;
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(urlRegex)) {
+    container.append(document.createTextNode(text.slice(lastIndex, match.index)));
+    const url = match[0];
+    const link = document.createElement("a");
+    link.href = url;
+    link.textContent = url;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    container.append(link);
+    lastIndex = match.index + url.length;
+  }
+
+  container.append(document.createTextNode(text.slice(lastIndex)));
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   console.log("Popup loaded, preparing to check site status...");
 
@@ -401,10 +421,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // Handle reason display in dedicated container
     if (reason && (status === "unsafe" || status === "potentially_unsafe")) {
-      // Convert URLs to clickable links
-      const urlRegex = /(https?:\/\/[^\s]+)/g;
-      const formattedReason = reason.replace(urlRegex, '<a href="$1" target="_blank">$1</a>');
-      reasonContent.innerHTML = formattedReason;
+      renderTextWithLinks(reasonContent, reason);
       reasonContainer.classList.add("visible");
     } else {
       reasonContainer.classList.remove("visible");

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -317,8 +317,9 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, just show the hostname from the matched URL
-            displayUrl = matchedUrlObj.hostname;
+            // Preserve a canonical FMHY resource path without a trailing slash.
+            const matchedPath = matchedUrlObj.pathname.replace(/\/+$/, "");
+            displayUrl = matchedUrlObj.hostname + matchedPath;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -1,5 +1,10 @@
 function formatHostAndPath(urlObj) {
-  return urlObj.hostname + urlObj.pathname.replace(/\/+$/, "");
+  return (
+    urlObj.hostname +
+    urlObj.pathname.replace(/\/+$/, "") +
+    urlObj.search +
+    urlObj.hash
+  );
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -29,6 +34,18 @@ document.addEventListener("DOMContentLoaded", async () => {
     "github.com",
     "gist.github.com",
     "raw.githubusercontent.com",
+    "greasyfork.org",
+    "youtube.com",
+    "chromewebstore.google.com",
+    "colab.research.google.com",
+    "modrinth.com",
+    "f-droid.org",
+    "xdaforums.com",
+    "start.me",
+    "sites.google.com",
+    "matrix.to",
+    "codepen.io",
+    "vk.com",
     "gitlab.com",
     "codeberg.org",
     "sourceforge.net",

--- a/test-builds/chrome/pub/index.js
+++ b/test-builds/chrome/pub/index.js
@@ -317,8 +317,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, just show the hostname from the matched URL
-            displayUrl = matchedUrlObj.hostname;
+            // For regular sites, show the hostname currently being visited
+            displayUrl = currentUrlObj.hostname;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/test-builds/chrome/pub/warning-page.js
+++ b/test-builds/chrome/pub/warning-page.js
@@ -11,15 +11,29 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Display reason for unsafe site - prefer URL parameter, fallback to storage
   let reason = reasonFromUrl ? decodeURIComponent(reasonFromUrl) : null;
 
-  // Helper function to convert URLs to clickable links
-  function formatReasonWithLinks(text) {
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
-    return text.replace(urlRegex, '<a href="$1" target="_blank">$1</a>');
+  function renderTextWithLinks(container, text) {
+    container.replaceChildren();
+    const urlRegex = /https?:\/\/[^\s]+/g;
+    let lastIndex = 0;
+
+    for (const match of text.matchAll(urlRegex)) {
+      container.append(document.createTextNode(text.slice(lastIndex, match.index)));
+      const url = match[0];
+      const link = document.createElement("a");
+      link.href = url;
+      link.textContent = url;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      container.append(link);
+      lastIndex = match.index + url.length;
+    }
+
+    container.append(document.createTextNode(text.slice(lastIndex)));
   }
 
   if (reason) {
     console.log("Reason provided via URL parameter");
-    document.getElementById("reasonText").innerHTML = formatReasonWithLinks(reason);
+    renderTextWithLinks(document.getElementById("reasonText"), reason);
     document.getElementById("reasonContainer").style.display = "block";
   } else {
     // Fallback: try to fetch from storage
@@ -52,7 +66,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         console.log("Found reason:", reason ? "yes" : "no");
 
         if (reason) {
-          document.getElementById("reasonText").innerHTML = formatReasonWithLinks(reason);
+          renderTextWithLinks(document.getElementById("reasonText"), reason);
           document.getElementById("reasonContainer").style.display = "block";
         }
       } else {

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -1628,6 +1628,22 @@ if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
       createdAt: Date.now(),
     });
   });
+} else if (browserAPI.webRequest?.onBeforeRedirect?.addListener) {
+  browserAPI.webRequest.onBeforeRedirect.addListener(
+    (details) => {
+      if (details.tabId < 0) return;
+      const previous = redirectOrigins.get(details.tabId);
+      const continuesChain =
+        previous &&
+        normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+      redirectOrigins.set(details.tabId, {
+        originUrl: continuesChain ? previous.originUrl : details.url,
+        targetUrl: details.redirectUrl,
+        createdAt: Date.now(),
+      });
+    },
+    { urls: ["<all_urls>"], types: ["main_frame"] }
+  );
 } else {
   browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
     if (details.frameId === 0 && details.tabId >= 0) {

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -746,6 +746,12 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const isEnteAuthRedirect =
+    currentHost === "auth.ente.com" &&
+    currentPath === "/login" &&
+    listedHost === "ente.com" &&
+    listedPath === "/auth";
+  if (isEnteAuthRedirect) return true;
   if (!listedPath) return !sharedHost || !currentPath;
   return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
 }

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -134,6 +134,7 @@ const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
+let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -1158,6 +1159,7 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
+  if (initializationPromise) await initializationPromise;
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1338,6 +1340,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
+        if (initializationPromise) await initializationPromise;
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1901,4 +1904,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializeExtension();
+initializationPromise = initializeExtension();

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -81,6 +81,27 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
+const sharedResourceHosts = new Set([
+  "github.com",
+  "raw.githubusercontent.com",
+  "gitlab.com",
+  "codeberg.org",
+  "sourceforge.net",
+  "rentry.co",
+  "rentry.org",
+  "pastebin.com",
+  "archive.org",
+  "drive.google.com",
+  "docs.google.com",
+  "discord.com",
+  "discord.gg",
+  "t.me",
+  "mega.nz",
+  "mediafire.com",
+  "gofile.io",
+  "pixeldrain.com",
+  "huggingface.co",
+]);
 
 // State Variables
 let unsafeSitesRegex = null;
@@ -700,6 +721,35 @@ function normalizeUrl(url) {
   }
 }
 
+function isSharedResourceHost(hostname) {
+  const domain = hostname.replace(/^www\./, "").toLowerCase();
+  for (const host of sharedResourceHosts) {
+    if (domain === host || domain.endsWith(`.${host}`)) return true;
+  }
+  return false;
+}
+
+function urlMatchesListedResource(currentUrl, listedUrl) {
+  const normalizedCurrent = normalizeUrl(currentUrl);
+  const normalizedListed = normalizeUrl(listedUrl);
+  if (!normalizedCurrent || !normalizedListed) return false;
+
+  const current = new URL(normalizedCurrent);
+  const listed = new URL(normalizedListed);
+  const currentHost = current.hostname.replace(/^www\./, "").toLowerCase();
+  const listedHost = listed.hostname.replace(/^www\./, "").toLowerCase();
+  const sharedHost = isSharedResourceHost(currentHost) || isSharedResourceHost(listedHost);
+  const hostMatches = sharedHost
+    ? currentHost === listedHost
+    : currentHost === listedHost || currentHost.endsWith(`.${listedHost}`);
+  if (!hostMatches) return false;
+
+  const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
+  const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  if (!listedPath) return !sharedHost || !currentPath;
+  return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+}
+
 function extractRootUrl(url) {
   if (!url) {
     console.warn("Received null or undefined URL for root extraction.");
@@ -1160,10 +1210,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           return;
         }
 
-        // Special handling for repository sites
-        const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-          (d) => urlObj.hostname === d || urlObj.hostname.endsWith("." + d)
-        );
+        const requiresResourcePath = isSharedResourceHost(domain);
 
         // Variables to track status and matched URL
         let status = "no_data";
@@ -1179,39 +1226,22 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         } else if (fmhySitesRegex?.test(normalizedUrl)) {
           status = "fmhy";
           matchedUrl = normalizedUrl;
-        } else if (starredSites.includes(normalizedUrl)) {
+        } else if ((matchedUrl = starredSites.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "starred";
-          matchedUrl = normalizedUrl;
-        } else if (safeSites.includes(normalizedUrl)) {
+        } else if ((matchedUrl = safeSites.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "safe";
-          matchedUrl = normalizedUrl;
-        } else if (base64StarredLinks.some(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl))) {
+        } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "starred";
-          matchedUrl = normalizedUrl;
-        } else if (base64DecodedLinks.some(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl))) {
+        } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
+          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
           status = "safe";
-          matchedUrl = normalizedUrl;
         }
 
-        // If no match for full URL and it's a repository site, check Base64 links then return
-        if (status === "no_data" && isRepoSite) {
-          const base64StarredMatch = base64StarredLinks.find(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl));
-          if (base64StarredMatch) {
-            sendResponse({ status: "starred", matchedUrl: base64StarredMatch });
-            return;
-          }
-          const base64Match = base64DecodedLinks.find(link => normalizedUrl.startsWith(link) || link.startsWith(normalizedUrl));
-          if (base64Match) {
-            sendResponse({ status: "safe", matchedUrl: base64Match });
-            return;
-          }
-          console.log(`No match for repository URL: ${normalizedUrl}`);
-          sendResponse({ status: "no_data", matchedUrl: normalizedUrl });
-          return;
-        }
-
-        // If no match for full URL and it's a regular site, try domain-level matching
-        if (status === "no_data" && !isRepoSite) {
+        // Shared hosts require a matching resource path; normal sites can use domain rules.
+        if (status === "no_data" && !requiresResourcePath) {
           console.log(`No match for full URL, trying domain: ${domain}`);
 
           // Check domain against regex patterns (use hostname-only regex for domain matching)
@@ -1222,69 +1252,6 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           } else if (potentiallyUnsafeHostnamesRegex?.test(domain)) {
             status = "potentially_unsafe";
             matchedUrl = `https://${domain}`;
-          }
-
-          // Check domain against starred and safe lists
-          if (status === "no_data") {
-            for (const starredUrl of starredSites) {
-              try {
-                const starredUrlObj = new URL(starredUrl);
-                if (starredUrlObj.hostname === domain) {
-                  status = "starred";
-                  matchedUrl = starredUrl;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          if (status === "no_data") {
-            for (const safeUrl of safeSites) {
-              try {
-                const safeUrlObj = new URL(safeUrl);
-                if (safeUrlObj.hostname === domain) {
-                  status = "safe";
-                  matchedUrl = safeUrl;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          // Check Base64 starred links by domain first
-          if (status === "no_data") {
-            for (const b64Url of base64StarredLinks) {
-              try {
-                const b64UrlObj = new URL(b64Url);
-                if (b64UrlObj.hostname === domain) {
-                  status = "starred";
-                  matchedUrl = b64Url;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
-          }
-
-          // Check Base64 decoded links by domain
-          if (status === "no_data") {
-            for (const b64Url of base64DecodedLinks) {
-              try {
-                const b64UrlObj = new URL(b64Url);
-                if (b64UrlObj.hostname === domain) {
-                  status = "safe";
-                  matchedUrl = b64Url;
-                  break;
-                }
-              } catch (e) {
-                continue;
-              }
-            }
           }
         }
 
@@ -1389,78 +1356,22 @@ function getStatusFromLists(url) {
     if (userUntrustedDomains.has(normalizedDomain)) {
       return "unsafe";
     }
-    const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-      (domain) =>
-        urlObj.hostname === domain || urlObj.hostname.endsWith("." + domain)
-    );
+    const requiresResourcePath = isSharedResourceHost(domain);
 
-    // For repository sites, need exact path matching
-    if (isRepoSite) {
-      // Check unsafe and potentially unsafe first
-      if (unsafeSitesRegex?.test(url)) return "unsafe";
-      if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
-      if (fmhySitesRegex?.test(url)) return "fmhy";
-      if (starredSites.includes(url)) return "starred";
-      if (safeSites.includes(url)) return "safe";
-      // Check Base64 starred links first, then safe links (exact URL match for repos)
-      if (base64StarredLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "starred";
-      if (base64DecodedLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "safe";
-      return "no_data"; // No domain-only matches for repos
-    }
-
-    // For normal sites, direct checks first (full URL)
     if (unsafeSitesRegex?.test(url)) return "unsafe";
     if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
     if (fmhySitesRegex?.test(url)) return "fmhy";
-    if (starredSites.includes(url)) return "starred";
-    if (safeSites.includes(url)) return "safe";
-    // Check Base64 starred links first, then safe links
-    if (base64StarredLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "starred";
-    if (base64DecodedLinks.some(link => url.startsWith(link) || link.startsWith(url))) return "safe";
+    if (starredSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
+    if (safeSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+    if (base64StarredLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
+    if (base64DecodedLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+
+    if (requiresResourcePath) return "no_data";
 
     // Then check domain-level (use hostname-only regex for domain matching)
     // Note: FMHY sites only match exact URLs, not domain-level
     if (unsafeHostnamesRegex?.test(domain)) return "unsafe";
     if (potentiallyUnsafeHostnamesRegex?.test(domain)) return "potentially_unsafe";
-
-    // Try domain-level checks for starred and safe
-    for (const starredUrl of starredSites) {
-      try {
-        const starredUrlObj = new URL(starredUrl);
-        if (starredUrlObj.hostname === domain) return "starred";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    for (const safeUrl of safeSites) {
-      try {
-        const safeUrlObj = new URL(safeUrl);
-        if (safeUrlObj.hostname === domain) return "safe";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    // Check Base64 starred links by domain first
-    for (const b64Url of base64StarredLinks) {
-      try {
-        const b64UrlObj = new URL(b64Url);
-        if (b64UrlObj.hostname === domain) return "starred";
-      } catch (e) {
-        continue;
-      }
-    }
-
-    // Check Base64 decoded links by domain
-    for (const b64Url of base64DecodedLinks) {
-      try {
-        const b64UrlObj = new URL(b64Url);
-        if (b64UrlObj.hostname === domain) return "safe";
-      } catch (e) {
-        continue;
-      }
-    }
 
     return "no_data";
   } catch (e) {
@@ -1712,9 +1623,6 @@ async function initializeExtension() {
         console.error("Error loading from storage:", error);
       }
     }
-
-    // Add fallback known sites - only for safe sites, not for starred
-    addKnownSafeSites();
 
     // Set up the update schedule
     await setupUpdateSchedule();

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -459,22 +459,33 @@ const notesPatterns = [
 const sitePasswords = {
   "cs.rin.ru": "cs.rin.ru",
   "csrin.org": "csrin.org",
+  "steamrip.com": "steamrip.com",
   "online-fix.me": "online-fix.me",
   "ovagames.com": "www.ovagames.com",
   "g4u.to": "404",
   "elenemigos.com": "elenemigos.com",
   "triahgames.com": "www.triahgames.com",
   "soft98.ir": "soft98.ir",
+  "iptv.watchott.ru": "FREE-MEDIA",
+};
+
+// Passwords for resources that share a host and must be matched by URL.
+const siteUrlPasswords = {
+  "https://rentry.co/fmhyb64#gnarly": "gnarly",
+  "https://rentry.co/fmhyb64#alvro": "ByAlvRo",
 };
 
 // Hardcoded site invite codes - Maps domains to their invite codes
 const siteInviteCodes = {
   "ee3.me": "mpgh",
-  "rips.cc": "mpgh",
+  "rips.cc": "1hack",
 };
 
 // Get password for a domain
-function getPasswordForDomain(hostname) {
+function getPasswordForDomain(hostname, url = "") {
+  const urlPassword = siteUrlPasswords[url.toLowerCase().replace(/\/$/, "")];
+  if (urlPassword) return urlPassword;
+
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   return sitePasswords[domain] || null;
 }
@@ -1259,7 +1270,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         // Get password if available
-        const password = getPasswordForDomain(domain);
+        const password = getPasswordForDomain(domain, url);
 
         // Get invite code if available
         const inviteCode = getInviteCodeForDomain(domain);

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -539,6 +539,31 @@ async function getReasonForDomain(hostname) {
   return null;
 }
 
+function getReasonKeyForUrl(url) {
+  try {
+    const urlObj = new URL(url);
+    const domain = urlObj.hostname.replace(/^www\./, "").toLowerCase();
+    const pathname = urlObj.pathname.replace(/\/+$/, "").toLowerCase();
+    return pathname ? `${domain}${pathname}` : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+async function getReasonForUrl(url) {
+  const reasonKey = getReasonKeyForUrl(url);
+  if (!reasonKey) return null;
+
+  const hostname = new URL(url).hostname;
+  await getReasonForDomain(hostname);
+
+  const matchedKey = Object.keys(unsafeReasons)
+    .filter((key) => key.includes("/") && (reasonKey === key || reasonKey.startsWith(`${key}/`)))
+    .sort((a, b) => b.length - a.length)[0];
+
+  return matchedKey ? unsafeReasons[matchedKey] : null;
+}
+
 // Fetch note content from GitHub
 async function fetchNoteContent(noteSlug) {
   // Check cache first
@@ -1263,10 +1288,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
+        const pathSpecificReason = await getReasonForUrl(url);
+        if (status === "no_data" && pathSpecificReason) {
+          status = "unsafe";
+          matchedUrl = normalizedUrl;
+        }
+
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = await getReasonForDomain(domain);
+          reason = pathSpecificReason || await getReasonForDomain(domain);
         }
 
         // Get password if available
@@ -1469,7 +1500,7 @@ async function openWarningPage(tabId, unsafeUrl) {
   } catch (e) {
     hostname = unsafeUrl.replace(/^https?:\/\//, "").split("/")[0];
   }
-  const reason = await getReasonForDomain(hostname);
+  const reason = await getReasonForUrl(unsafeUrl) || await getReasonForDomain(hostname);
   console.log(`openWarningPage: hostname=${hostname}, reason=${reason ? "found" : "not found"}`);
 
   // Redirect to the warning page if it is enabled in settings

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -1032,7 +1032,7 @@ async function notifySettingsPage() {
 }
 
 // Site Status Checking
-function checkSiteAndUpdatePageAction(tabId, url) {
+async function checkSiteAndUpdatePageAction(tabId, url) {
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1083,6 +1083,13 @@ function checkSiteAndUpdatePageAction(tabId, url) {
       status = getStatusFromLists(rootUrl + "/");
       if (status !== "no_data") matchedUrl = rootUrl + "/";
     }
+  }
+
+  // A path-specific reason can classify a resource even when it is absent from
+  // the domain filter lists. Keep the toolbar icon aligned with the popup.
+  if (status === "no_data" && await getReasonForUrl(url)) {
+    status = "unsafe";
+    matchedUrl = normalizedUrl;
   }
 
   // Apply the correct icon status to the tab

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -130,6 +130,7 @@ let starredSites = [];
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
+const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
@@ -758,6 +759,40 @@ function normalizeResourceUrl(url) {
   }
 }
 
+function getRedirectOrigin(tabId, currentUrl) {
+  if (!Number.isInteger(tabId)) return null;
+  const redirect = redirectOrigins.get(tabId);
+  if (!redirect || Date.now() - redirect.createdAt > 2 * 60 * 1000) {
+    redirectOrigins.delete(tabId);
+    return null;
+  }
+  return normalizeResourceUrl(redirect.targetUrl) === normalizeResourceUrl(currentUrl)
+    ? redirect.originUrl
+    : null;
+}
+
+function getListedResourceStatus(url) {
+  let matchedUrl = starredSites.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "starred", matchedUrl };
+
+  matchedUrl = safeSites.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "safe", matchedUrl };
+
+  matchedUrl = base64StarredLinks.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  if (matchedUrl) return { status: "starred", matchedUrl };
+
+  matchedUrl = base64DecodedLinks.find((listedUrl) =>
+    urlMatchesListedResource(url, listedUrl)
+  );
+  return matchedUrl ? { status: "safe", matchedUrl } : null;
+}
+
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -783,6 +818,19 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const currentGreasyForkScript = currentPath.match(
+    /^\/(?:[^/]+\/)?scripts\/(\d+)/
+  );
+  const listedGreasyForkScript = listedPath.match(
+    /^\/(?:[^/]+\/)?scripts\/(\d+)/
+  );
+  if (
+    currentHost === "greasyfork.org" &&
+    listedHost === "greasyfork.org" &&
+    currentGreasyForkScript?.[1] === listedGreasyForkScript?.[1]
+  ) {
+    return true;
+  }
   const isGistPlatformPage =
     currentHost === "gist.github.com" &&
     ["/starred", "/discover"].includes(currentPath) &&
@@ -1181,6 +1229,16 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
     matchedUrl = normalizedUrl;
   }
 
+  if (status === "no_data") {
+    const redirectOrigin = getRedirectOrigin(tabId, url);
+    if (redirectOrigin) {
+      status = getStatusFromLists(normalizeResourceUrl(redirectOrigin));
+      if (status === "no_data" && await getReasonForUrl(redirectOrigin)) {
+        status = "unsafe";
+      }
+    }
+  }
+
   // Apply the correct icon status to the tab
   updatePageAction(status, tabId);
 
@@ -1352,16 +1410,35 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
-        const pathSpecificReason = await getReasonForUrl(url);
+        let reasonDomain = domain;
+        let pathSpecificReason = await getReasonForUrl(url);
         if (status === "no_data" && pathSpecificReason) {
           status = "unsafe";
           matchedUrl = normalizedUrl;
         }
 
+        if (status === "no_data") {
+          const redirectOrigin = getRedirectOrigin(message.tabId, url);
+          const redirectResourceUrl = normalizeResourceUrl(redirectOrigin);
+          if (redirectResourceUrl) {
+            status = getStatusFromLists(redirectResourceUrl);
+            const listedMatch = getListedResourceStatus(redirectResourceUrl);
+            matchedUrl = listedMatch?.matchedUrl || null;
+            reasonDomain = new URL(redirectResourceUrl).hostname;
+            pathSpecificReason = await getReasonForUrl(redirectOrigin);
+            if (status === "no_data" && pathSpecificReason) {
+              status = "unsafe";
+              matchedUrl = normalizeUrl(redirectOrigin);
+            } else if (status !== "no_data" && !matchedUrl) {
+              matchedUrl = normalizeUrl(redirectOrigin);
+            }
+          }
+        }
+
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = pathSpecificReason || await getReasonForDomain(domain);
+          reason = pathSpecificReason || await getReasonForDomain(reasonDomain);
         }
 
         // Get password if available
@@ -1533,6 +1610,19 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 // Listen for tab updates
+browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
+  if (details.frameId !== 0 || details.tabId < 0) return;
+  const previous = redirectOrigins.get(details.tabId);
+  const continuesChain =
+    previous &&
+    normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+  redirectOrigins.set(details.tabId, {
+    originUrl: continuesChain ? previous.originUrl : details.url,
+    targetUrl: details.redirectUrl,
+    createdAt: Date.now(),
+  });
+});
+
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
@@ -1558,6 +1648,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
+  redirectOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -130,12 +130,9 @@ let starredSites = [];
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
-const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
-const pendingNavigationOrigins = new Map(); // Firefox redirect fallback origins
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
-let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -761,40 +758,6 @@ function normalizeResourceUrl(url) {
   }
 }
 
-function getRedirectOrigin(tabId, currentUrl) {
-  if (!Number.isInteger(tabId)) return null;
-  const redirect = redirectOrigins.get(tabId);
-  if (!redirect || Date.now() - redirect.createdAt > 2 * 60 * 1000) {
-    redirectOrigins.delete(tabId);
-    return null;
-  }
-  return normalizeResourceUrl(redirect.targetUrl) === normalizeResourceUrl(currentUrl)
-    ? redirect.originUrl
-    : null;
-}
-
-function getListedResourceStatus(url) {
-  let matchedUrl = starredSites.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "starred", matchedUrl };
-
-  matchedUrl = safeSites.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "safe", matchedUrl };
-
-  matchedUrl = base64StarredLinks.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  if (matchedUrl) return { status: "starred", matchedUrl };
-
-  matchedUrl = base64DecodedLinks.find((listedUrl) =>
-    urlMatchesListedResource(url, listedUrl)
-  );
-  return matchedUrl ? { status: "safe", matchedUrl } : null;
-}
-
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -1160,7 +1123,6 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
-  if (initializationPromise) await initializationPromise;
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1230,16 +1192,6 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   if (status === "no_data" && await getReasonForUrl(url)) {
     status = "unsafe";
     matchedUrl = normalizedUrl;
-  }
-
-  if (status === "no_data") {
-    const redirectOrigin = getRedirectOrigin(tabId, url);
-    if (redirectOrigin) {
-      status = getStatusFromLists(normalizeResourceUrl(redirectOrigin));
-      if (status === "no_data" && await getReasonForUrl(redirectOrigin)) {
-        status = "unsafe";
-      }
-    }
   }
 
   // Apply the correct icon status to the tab
@@ -1341,7 +1293,6 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
-        if (initializationPromise) await initializationPromise;
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1414,35 +1365,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           }
         }
 
-        let reasonDomain = domain;
-        let pathSpecificReason = await getReasonForUrl(url);
+        const pathSpecificReason = await getReasonForUrl(url);
         if (status === "no_data" && pathSpecificReason) {
           status = "unsafe";
           matchedUrl = normalizedUrl;
         }
 
-        if (status === "no_data") {
-          const redirectOrigin = getRedirectOrigin(message.tabId, url);
-          const redirectResourceUrl = normalizeResourceUrl(redirectOrigin);
-          if (redirectResourceUrl) {
-            status = getStatusFromLists(redirectResourceUrl);
-            const listedMatch = getListedResourceStatus(redirectResourceUrl);
-            matchedUrl = listedMatch?.matchedUrl || null;
-            reasonDomain = new URL(redirectResourceUrl).hostname;
-            pathSpecificReason = await getReasonForUrl(redirectOrigin);
-            if (status === "no_data" && pathSpecificReason) {
-              status = "unsafe";
-              matchedUrl = normalizeUrl(redirectOrigin);
-            } else if (status !== "no_data" && !matchedUrl) {
-              matchedUrl = normalizeUrl(redirectOrigin);
-            }
-          }
-        }
-
         // Get reason if unsafe
         let reason = null;
         if (status === "unsafe" || status === "potentially_unsafe") {
-          reason = pathSpecificReason || await getReasonForDomain(reasonDomain);
+          reason = pathSpecificReason || await getReasonForDomain(domain);
         }
 
         // Get password if available
@@ -1613,61 +1545,7 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
-// Track server redirects. Firefox lacks webNavigation.onBeforeRedirect, so use
-// its redirect-qualified navigation commit as a fallback.
-if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
-  browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
-    if (details.frameId !== 0 || details.tabId < 0) return;
-    const previous = redirectOrigins.get(details.tabId);
-    const continuesChain =
-      previous &&
-      normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-    redirectOrigins.set(details.tabId, {
-      originUrl: continuesChain ? previous.originUrl : details.url,
-      targetUrl: details.redirectUrl,
-      createdAt: Date.now(),
-    });
-  });
-} else if (browserAPI.webRequest?.onBeforeRedirect?.addListener) {
-  browserAPI.webRequest.onBeforeRedirect.addListener(
-    (details) => {
-      if (details.tabId < 0) return;
-      const previous = redirectOrigins.get(details.tabId);
-      const continuesChain =
-        previous &&
-        normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-      redirectOrigins.set(details.tabId, {
-        originUrl: continuesChain ? previous.originUrl : details.url,
-        targetUrl: details.redirectUrl,
-        createdAt: Date.now(),
-      });
-    },
-    { urls: ["<all_urls>"], types: ["main_frame"] }
-  );
-} else {
-  browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
-    if (details.frameId === 0 && details.tabId >= 0) {
-      pendingNavigationOrigins.set(details.tabId, details.url);
-    }
-  });
-  browserAPI.webNavigation?.onCommitted?.addListener((details) => {
-    if (details.frameId !== 0 || details.tabId < 0) return;
-    const originUrl = pendingNavigationOrigins.get(details.tabId);
-    pendingNavigationOrigins.delete(details.tabId);
-    if (
-      originUrl &&
-      details.transitionQualifiers?.includes("server_redirect") &&
-      normalizeResourceUrl(originUrl) !== normalizeResourceUrl(details.url)
-    ) {
-      redirectOrigins.set(details.tabId, {
-        originUrl,
-        targetUrl: details.url,
-        createdAt: Date.now(),
-      });
-    }
-  });
-}
-
+// Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
@@ -1693,8 +1571,6 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
-  redirectOrigins.delete(tabId);
-  pendingNavigationOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 
@@ -1947,4 +1823,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializationPromise = initializeExtension();
+initializeExtension();

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -131,6 +131,7 @@ let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
 const redirectOrigins = new Map(); // Navigation-scoped redirect origins per tab
+const pendingNavigationOrigins = new Map(); // Firefox redirect fallback origins
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
@@ -1612,19 +1613,44 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
-// Listen for tab updates
-browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
-  if (details.frameId !== 0 || details.tabId < 0) return;
-  const previous = redirectOrigins.get(details.tabId);
-  const continuesChain =
-    previous &&
-    normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
-  redirectOrigins.set(details.tabId, {
-    originUrl: continuesChain ? previous.originUrl : details.url,
-    targetUrl: details.redirectUrl,
-    createdAt: Date.now(),
+// Track server redirects. Firefox lacks webNavigation.onBeforeRedirect, so use
+// its redirect-qualified navigation commit as a fallback.
+if (browserAPI.webNavigation?.onBeforeRedirect?.addListener) {
+  browserAPI.webNavigation.onBeforeRedirect.addListener((details) => {
+    if (details.frameId !== 0 || details.tabId < 0) return;
+    const previous = redirectOrigins.get(details.tabId);
+    const continuesChain =
+      previous &&
+      normalizeResourceUrl(previous.targetUrl) === normalizeResourceUrl(details.url);
+    redirectOrigins.set(details.tabId, {
+      originUrl: continuesChain ? previous.originUrl : details.url,
+      targetUrl: details.redirectUrl,
+      createdAt: Date.now(),
+    });
   });
-});
+} else {
+  browserAPI.webNavigation?.onBeforeNavigate?.addListener((details) => {
+    if (details.frameId === 0 && details.tabId >= 0) {
+      pendingNavigationOrigins.set(details.tabId, details.url);
+    }
+  });
+  browserAPI.webNavigation?.onCommitted?.addListener((details) => {
+    if (details.frameId !== 0 || details.tabId < 0) return;
+    const originUrl = pendingNavigationOrigins.get(details.tabId);
+    pendingNavigationOrigins.delete(details.tabId);
+    if (
+      originUrl &&
+      details.transitionQualifiers?.includes("server_redirect") &&
+      normalizeResourceUrl(originUrl) !== normalizeResourceUrl(details.url)
+    ) {
+      redirectOrigins.set(details.tabId, {
+        originUrl,
+        targetUrl: details.url,
+        createdAt: Date.now(),
+      });
+    }
+  });
+}
 
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.url) {
@@ -1652,6 +1678,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
   redirectOrigins.delete(tabId);
+  pendingNavigationOrigins.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -1555,9 +1555,14 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (changeInfo.url) {
+    await checkSiteAndUpdatePageAction(tabId, changeInfo.url);
+    return;
+  }
+
   if (changeInfo.status === "complete" && tab.url) {
     // Always check the site status
-    checkSiteAndUpdatePageAction(tabId, tab.url);
+    await checkSiteAndUpdatePageAction(tabId, tab.url);
   }
 });
 

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -81,7 +81,7 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
-const resourceIdentityVersion = 1;
+const resourceIdentityVersion = 2;
 const sharedResourceHosts = new Set([
   "github.com",
   "gist.github.com",
@@ -622,7 +622,7 @@ async function fetchNoteContent(noteSlug) {
   }
 }
 function extractUrlsFromMarkdown(markdown) {
-  const urlRegex = /https?:\/\/[^\s)]+/g;
+  const urlRegex = /https?:\/\/[^\s)>]+/g;
   return markdown.match(urlRegex) || [];
 }
 
@@ -669,6 +669,9 @@ function extractFmhyResourceMap(markdown, guideUrl) {
     }
 
     for (const match of line.matchAll(/\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g)) {
+      resourceMap[match[1]] = sectionUrl;
+    }
+    for (const match of line.matchAll(/<(https?:\/\/[^>\s]+)>/g)) {
       resourceMap[match[1]] = sectionUrl;
     }
   }

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -1051,6 +1051,9 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
 
   const normalizedUrl = normalizeUrl(url.trim());
   const rootUrl = extractRootUrl(normalizedUrl);
+  const requiresResourcePath = normalizedUrl
+    ? isSharedResourceHost(new URL(normalizedUrl).hostname)
+    : false;
 
   // Detect if the URL is an internal extension page (settings page or warning page)
   const extUrlBase = browserAPI.runtime.getURL("");
@@ -1081,7 +1084,7 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   }
 
   // If still no match, check the root URL
-  if (status === "no_data") {
+  if (status === "no_data" && !requiresResourcePath) {
     status = getStatusFromLists(rootUrl);
     if (status !== "no_data") matchedUrl = rootUrl;
 

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -81,10 +81,23 @@ const unsafeReasonsURL =
   "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/refs/heads/main/filterlists-reasons.json";
 const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
+const resourceIdentityVersion = 1;
 const sharedResourceHosts = new Set([
   "github.com",
   "gist.github.com",
   "raw.githubusercontent.com",
+  "greasyfork.org",
+  "youtube.com",
+  "chromewebstore.google.com",
+  "colab.research.google.com",
+  "modrinth.com",
+  "f-droid.org",
+  "xdaforums.com",
+  "start.me",
+  "sites.google.com",
+  "matrix.to",
+  "codepen.io",
+  "vk.com",
   "gitlab.com",
   "codeberg.org",
   "sourceforge.net",
@@ -664,7 +677,7 @@ function extractFmhyResourceMap(markdown, guideUrl) {
 }
 
 function getFmhyUrlForMatch(matchedUrl) {
-  const normalizedUrl = normalizeUrl(matchedUrl);
+  const normalizedUrl = normalizeResourceUrl(matchedUrl);
   if (!normalizedUrl) return null;
   return fmhyResourceMap[normalizedUrl] || null;
 }
@@ -728,6 +741,23 @@ function normalizeUrl(url) {
   }
 }
 
+function normalizeResourceUrl(url) {
+  const normalized = normalizeUrl(url);
+  if (!normalized) return null;
+
+  try {
+    const source = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+    const sourceObj = new URL(source);
+    const normalizedObj = new URL(normalized);
+    normalizedObj.search = sourceObj.search;
+    normalizedObj.hash = sourceObj.hash;
+    return normalizedObj.href;
+  } catch (error) {
+    console.warn(`Invalid resource URL skipped: ${url} - ${error.message}`);
+    return null;
+  }
+}
+
 function isSharedResourceHost(hostname) {
   const domain = hostname.replace(/^www\./, "").toLowerCase();
   for (const host of sharedResourceHosts) {
@@ -737,8 +767,8 @@ function isSharedResourceHost(hostname) {
 }
 
 function urlMatchesListedResource(currentUrl, listedUrl) {
-  const normalizedCurrent = normalizeUrl(currentUrl);
-  const normalizedListed = normalizeUrl(listedUrl);
+  const normalizedCurrent = normalizeResourceUrl(currentUrl);
+  const normalizedListed = normalizeResourceUrl(listedUrl);
   if (!normalizedCurrent || !normalizedListed) return false;
 
   const current = new URL(normalizedCurrent);
@@ -765,8 +795,32 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
     listedHost === "ente.com" &&
     listedPath === "/auth";
   if (isEnteAuthRedirect) return true;
-  if (!listedPath) return !sharedHost || !currentPath;
-  return currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+  const pathMatches = !listedPath
+    ? !sharedHost || !currentPath
+    : currentPath === listedPath || currentPath.startsWith(`${listedPath}/`);
+  if (!pathMatches) return false;
+
+  const queryIdentifiesResource = ["youtube.com", "archive.org"].includes(
+    listedHost
+  );
+  if (queryIdentifiesResource) {
+    for (const [key, value] of listed.searchParams) {
+      if (current.searchParams.get(key) !== value) return false;
+    }
+  }
+  const fragmentIdentifiesResource = [
+    "rentry.co",
+    "rentry.org",
+    "matrix.to",
+  ].includes(listedHost);
+  if (
+    fragmentIdentifiesResource &&
+    listed.hash &&
+    current.hash.toLowerCase() !== listed.hash.toLowerCase()
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function extractRootUrl(url) {
@@ -935,7 +989,7 @@ async function fetchSafeSites() {
         const guideUrl = `https://fmhy.net/${guideName}`;
         const guideMap = extractFmhyResourceMap(markdown, guideUrl);
         for (const [resourceUrl, fmhyUrl] of Object.entries(guideMap)) {
-          const normalizedResourceUrl = normalizeUrl(resourceUrl);
+          const normalizedResourceUrl = normalizeResourceUrl(resourceUrl);
           if (normalizedResourceUrl) fmhyResourceMap[normalizedResourceUrl] = fmhyUrl;
         }
       } else {
@@ -944,13 +998,16 @@ async function fetchSafeSites() {
     }
 
     // Normalize URLs and remove duplicates
-    safeSites = [...new Set(allUrls.map((url) => normalizeUrl(url.trim())))];
+    safeSites = [
+      ...new Set(allUrls.map((url) => normalizeResourceUrl(url.trim()))),
+    ].filter((url) => url !== null);
 
     // Store safe sites for content script use
     await browserAPI.storage.local.set({
       safeSiteCount: safeSites.length,
       safeSiteList: safeSites,
       fmhyResourceMap,
+      resourceIdentityVersion,
     });
 
     console.log("Stored safe site count:", safeSites.length);
@@ -982,7 +1039,7 @@ async function fetchStarredSites() {
     starredSites = Array.from(
       new Set(
         starredUrls
-          .map((url) => normalizeUrl(url))
+          .map((url) => normalizeResourceUrl(url))
           .filter((url) => url !== null)
       )
     );
@@ -990,6 +1047,7 @@ async function fetchStarredSites() {
     await browserAPI.storage.local.set({
       starredSites,
       starredSiteCount: starredSites.length,
+      resourceIdentityVersion,
     });
 
     console.log(`Stored ${starredSites.length} starred sites`);
@@ -1062,6 +1120,7 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   }
 
   const normalizedUrl = normalizeUrl(url.trim());
+  const resourceUrl = normalizeResourceUrl(url.trim());
   const rootUrl = extractRootUrl(normalizedUrl);
   const requiresResourcePath = normalizedUrl
     ? isSharedResourceHost(new URL(normalizedUrl).hostname)
@@ -1081,16 +1140,24 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   let matchedUrl = normalizedUrl;
 
   // First check the full URL
-  status = getStatusFromLists(normalizedUrl);
+  status = getStatusFromLists(resourceUrl);
 
   // If not found, try with trailing slash
-  if (status === "no_data" && !normalizedUrl.endsWith("/")) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    !normalizedUrl.endsWith("/")
+  ) {
     status = getStatusFromLists(normalizedUrl + "/");
     if (status !== "no_data") matchedUrl = normalizedUrl + "/";
   }
 
   // If not found, try without trailing slash
-  if (status === "no_data" && normalizedUrl.endsWith("/")) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    normalizedUrl.endsWith("/")
+  ) {
     status = getStatusFromLists(normalizedUrl.slice(0, -1));
     if (status !== "no_data") matchedUrl = normalizedUrl.slice(0, -1);
   }
@@ -1224,7 +1291,8 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
         // Normalize the URL
         const normalizedUrl = normalizeUrl(url);
-        if (!normalizedUrl) {
+        const resourceUrl = normalizeResourceUrl(url);
+        if (!normalizedUrl || !resourceUrl) {
           sendResponse({ status: "no_data", matchedUrl: null });
           return;
         }
@@ -1256,16 +1324,16 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
           status = "fmhy";
           matchedUrl = normalizedUrl;
         } else if ((matchedUrl = starredSites.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "starred";
         } else if ((matchedUrl = safeSites.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "safe";
         } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "starred";
         } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
-          urlMatchesListedResource(normalizedUrl, listedUrl)))) {
+          urlMatchesListedResource(resourceUrl, listedUrl)))) {
           status = "safe";
         }
 
@@ -1575,7 +1643,10 @@ async function initializeExtension() {
           "safeSiteList",
           "fmhyResourceMap",
           "unsafeReasons",
+          "resourceIdentityVersion",
         ]);
+        const hasCurrentResourceIdentity =
+          storedData.resourceIdentityVersion === resourceIdentityVersion;
 
         if (storedData.unsafeSites && storedData.unsafeSites.length > 0) {
           unsafeSitesRegex = generateRegexFromList(storedData.unsafeSites);
@@ -1622,7 +1693,11 @@ async function initializeExtension() {
         }
 
         // Load starred sites from storage
-        if (storedData.starredSites && storedData.starredSites.length > 0) {
+        if (
+          hasCurrentResourceIdentity &&
+          storedData.starredSites &&
+          storedData.starredSites.length > 0
+        ) {
           starredSites = storedData.starredSites;
           console.log(
             `Loaded ${starredSites.length} starred sites from storage`
@@ -1635,7 +1710,11 @@ async function initializeExtension() {
         fmhyResourceMap = storedData.fmhyResourceMap || {};
 
         // Load safe sites and their FMHY guide locations from storage
-        if (storedData.safeSiteList && storedData.safeSiteList.length > 0) {
+        if (
+          hasCurrentResourceIdentity &&
+          storedData.safeSiteList &&
+          storedData.safeSiteList.length > 0
+        ) {
           safeSites = storedData.safeSiteList;
           console.log(`Loaded ${safeSites.length} safe sites from storage`);
           const hasLegacyAnchors = Object.values(fmhyResourceMap).some(

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -87,6 +87,7 @@ const sharedResourceHosts = new Set([
   "gitlab.com",
   "codeberg.org",
   "sourceforge.net",
+  "linktr.ee",
   "rentry.co",
   "rentry.org",
   "pastebin.com",

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -855,10 +855,15 @@ function extractRootUrl(url) {
 }
 
 function generateRegexFromList(list) {
-  const escapedList = list.map((domain) =>
-    domain.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-  );
-  return new RegExp(`(${escapedList.join("|")})`, "i");
+  if (!list.length) return /(?!)/;
+
+  const boundedPatterns = list.map((entry) => {
+    const escaped = entry.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return entry.includes("://")
+      ? `^${escaped}(?=$|[/?#])`
+      : `(?:^|\\.)${escaped}$`;
+  });
+  return new RegExp(`(?:${boundedPatterns.join("|")})`, "i");
 }
 
 function extractUrlsFromFilterList(text) {

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -83,6 +83,7 @@ const notesBaseURL =
   "https://raw.githubusercontent.com/fmhy/edit/main/docs/.vitepress/notes/";
 const sharedResourceHosts = new Set([
   "github.com",
+  "gist.github.com",
   "raw.githubusercontent.com",
   "gitlab.com",
   "codeberg.org",
@@ -618,8 +619,13 @@ function extractStarredUrlsFromMarkdown(markdown) {
   for (const line of markdown.split("\n")) {
     if (!line.includes("⭐")) continue;
 
-    const boldSections = line.match(/\*\*.*?\*\*/g) || [];
-    for (const section of boldSections) {
+    const descriptionSeparator = line.search(/\s+-\s+/);
+    const resourceGroup =
+      descriptionSeparator === -1 ? null : line.slice(0, descriptionSeparator);
+    const sections = resourceGroup
+      ? [resourceGroup]
+      : line.match(/\*\*.*?\*\*/g) || [];
+    for (const section of sections) {
       const links = section.matchAll(/\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/g);
       for (const match of links) {
         starredUrls.push(match[1]);
@@ -747,6 +753,12 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
 
   const currentPath = current.pathname.replace(/\/+$/, "").toLowerCase();
   const listedPath = listed.pathname.replace(/\/+$/, "").toLowerCase();
+  const isGistPlatformPage =
+    currentHost === "gist.github.com" &&
+    ["/starred", "/discover"].includes(currentPath) &&
+    listedHost === "gist.github.com" &&
+    !listedPath;
+  if (isGistPlatformPage) return true;
   const isEnteAuthRedirect =
     currentHost === "auth.ente.com" &&
     currentPath === "/login" &&

--- a/test-builds/firefox/js/content.js
+++ b/test-builds/firefox/js/content.js
@@ -48,6 +48,19 @@ let userTrusted = new Set();
 let userUntrusted = new Set();
 let unsafeReasons = {};
 
+function setUnsafeBadgeContent(badge, reason) {
+  badge.replaceChildren();
+  const icon = document.createElement("span");
+  icon.style.cssText = "display: inline-block; font-size: 14px;";
+  icon.textContent = "⚠️";
+  badge.append(
+    icon,
+    document.createTextNode(
+      ` FMHY Unsafe Site${reason ? `: ${reason}` : ""}`,
+    ),
+  );
+}
+
 // Search engines where highlighting should be applied
 const searchEngines = [
   "google.com",
@@ -309,8 +322,7 @@ function setupObserver() {
                 const badge = document.createElement('span');
                 badge.className = 'fmhy-unsafe-badge';
                 const reason = getReasonForDomain(linkDomain);
-                const reasonText = reason ? `: ${reason}` : "";
-                badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+                setUnsafeBadgeContent(badge, reason);
                 badge.dataset.domain = linkDomain;
                 siteDiv.appendChild(badge);
               }
@@ -527,8 +539,7 @@ function addWarningBanner(link, reason = null) {
         if (!siteDiv.querySelector('.fmhy-unsafe-badge')) {
           const badge = document.createElement('span');
           badge.className = 'fmhy-unsafe-badge';
-          const reasonText = reason ? `: ${reason}` : "";
-          badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+          setUnsafeBadgeContent(badge, reason);
           siteDiv.appendChild(badge);
         }
       }
@@ -557,8 +568,7 @@ function addWarningBanner(link, reason = null) {
   });
 
   // Add the warning icon and text
-  const reasonText = reason ? `: ${reason}` : "";
-  badge.innerHTML = `<span style="display: inline-block; font-size: 14px;">⚠️</span> FMHY Unsafe Site${reasonText}`;
+  setUnsafeBadgeContent(badge, reason);
 
   // Google-specific margin adjustment
   if (currentDomain.includes("google")) {

--- a/test-builds/firefox/manifest.json
+++ b/test-builds/firefox/manifest.json
@@ -18,8 +18,12 @@
         "storage",
         "tabs",
         "webNavigation",
+        "webRequest",
         "alarms",
         "contextMenus"
+    ],
+    "host_permissions": [
+        "<all_urls>"
     ],
     "content_scripts": [
         {

--- a/test-builds/firefox/manifest.json
+++ b/test-builds/firefox/manifest.json
@@ -17,6 +17,7 @@
     "permissions": [
         "storage",
         "tabs",
+        "webNavigation",
         "alarms",
         "contextMenus"
     ],

--- a/test-builds/firefox/manifest.json
+++ b/test-builds/firefox/manifest.json
@@ -17,13 +17,8 @@
     "permissions": [
         "storage",
         "tabs",
-        "webNavigation",
-        "webRequest",
         "alarms",
         "contextMenus"
-    ],
-    "host_permissions": [
-        "<all_urls>"
     ],
     "content_scripts": [
         {

--- a/test-builds/firefox/manifest.json
+++ b/test-builds/firefox/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_extensionName__",
     "default_locale": "en",
     "author": "Kenneth Hendricks & contributors",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "icons": {
         "128": "res/ext_icon_144.png"
     },

--- a/test-builds/firefox/pub/index.html
+++ b/test-builds/firefox/pub/index.html
@@ -450,7 +450,7 @@
     </button>
   </div>
   <div id="status-container">
-    <img id="status-icon" class="status-image" src="safe.png" alt="Status Icon" />
+    <img id="status-icon" class="status-image" src="../res/icons/default.png" alt="Site status" />
     <p id="status-message" data-i18n="checkingSiteStatus">Checking site status...</p>
     <a id="fmhy-resource-link" target="_blank" rel="noopener noreferrer" data-i18n="viewOnFmhy">View on FMHY →</a>
   </div>

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -287,6 +287,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
+          tabId: activeTab.id,
         });
       } catch (msgError) {
         console.warn("Message send failed, retrying...", msgError);
@@ -295,6 +296,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
+          tabId: activeTab.id,
         });
       }
 

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -287,7 +287,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
-          tabId: activeTab.id,
         });
       } catch (msgError) {
         console.warn("Message send failed, retrying...", msgError);
@@ -296,7 +295,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         response = await browserAPI.runtime.sendMessage({
           action: "getSiteStatus",
           url: currentUrl,
-          tabId: activeTab.id,
         });
       }
 

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -27,6 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     "gitlab.com",
     "codeberg.org",
     "sourceforge.net",
+    "linktr.ee",
     "rentry.co",
     "rentry.org",
     "pastebin.com",

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -1,3 +1,7 @@
+function formatHostAndPath(urlObj) {
+  return urlObj.hostname + urlObj.pathname.replace(/\/+$/, "");
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   console.log("Popup loaded, preparing to check site status...");
 
@@ -23,6 +27,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   ]);
   const sharedResourceHosts = new Set([
     "github.com",
+    "gist.github.com",
     "raw.githubusercontent.com",
     "gitlab.com",
     "codeberg.org",
@@ -309,18 +314,17 @@ document.addEventListener("DOMContentLoaded", async () => {
                 if (currentPathParts.length >= 2) {
                   displayUrl = `${currentUrlObj.hostname}/${currentPathParts[0]}/${currentPathParts[1]}`;
                 } else {
-                  displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+                  displayUrl = formatHostAndPath(matchedUrlObj);
                 }
               } else {
-                displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+                displayUrl = formatHostAndPath(matchedUrlObj);
               }
             }
           } else if (isSharedResourceHost) {
-            displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
+            displayUrl = formatHostAndPath(matchedUrlObj);
           } else {
             // Preserve a canonical FMHY resource path without a trailing slash.
-            const matchedPath = matchedUrlObj.pathname.replace(/\/+$/, "");
-            displayUrl = matchedUrlObj.hostname + matchedPath;
+            displayUrl = formatHostAndPath(matchedUrlObj);
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);
@@ -338,10 +342,10 @@ document.addEventListener("DOMContentLoaded", async () => {
           if (pathParts.length >= 2) {
             displayUrl = `${urlObj.hostname}/${pathParts[0]}/${pathParts[1]}`;
           } else {
-            displayUrl = urlObj.hostname + urlObj.pathname;
+            displayUrl = formatHostAndPath(urlObj);
           }
         } else if (isSharedResourceHost) {
-          displayUrl = urlObj.hostname + urlObj.pathname;
+          displayUrl = formatHostAndPath(urlObj);
         } else {
           // For regular sites, just show the hostname
           displayUrl = urlObj.hostname;

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -317,8 +317,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, show the hostname currently being visited
-            displayUrl = currentUrlObj.hostname;
+            // For regular sites, just show the hostname from the matched URL
+            displayUrl = matchedUrlObj.hostname;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -462,12 +462,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       starred: "../res/icons/starred.png",
       browser_page: "../res/ext_icon_144.png",
       extension_page: "../res/ext_icon_144.png",
-      no_data: "../res/ext_icon_144.png",
+      no_data: "../res/icons/default.png",
       error: "../res/icons/error.png",
-      unknown: "../res/ext_icon_144.png",
+      unknown: "../res/icons/default.png",
     };
 
     statusIcon.src = icons[status] || icons["unknown"];
+    statusIcon.alt = status === "no_data" ? "Not listed in FMHY" : "Site status";
     statusMessage.innerHTML = message || "An unknown error occurred.";
 
     statusIcon.classList.add("active");

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -21,6 +21,27 @@ document.addEventListener("DOMContentLoaded", async () => {
     "codeberg.org",
     "sourceforge.net",
   ]);
+  const sharedResourceHosts = new Set([
+    "github.com",
+    "raw.githubusercontent.com",
+    "gitlab.com",
+    "codeberg.org",
+    "sourceforge.net",
+    "rentry.co",
+    "rentry.org",
+    "pastebin.com",
+    "archive.org",
+    "drive.google.com",
+    "docs.google.com",
+    "discord.com",
+    "discord.gg",
+    "t.me",
+    "mega.nz",
+    "mediafire.com",
+    "gofile.io",
+    "pixeldrain.com",
+    "huggingface.co",
+  ]);
   let fmhyLinkContext = null;
 
   fmhyResourceLink.addEventListener("click", async (event) => {
@@ -268,6 +289,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           const matchedUrlObj = new URL(response.matchedUrl);
           const currentUrlObj = new URL(currentUrl);
           const isRepoSite = repositoryHosts.has(matchedUrlObj.hostname);
+          const isSharedResourceHost = sharedResourceHosts.has(matchedUrlObj.hostname);
 
           if (isRepoSite) {
             // For repo sites, extract the domain and path parts that were matched
@@ -292,6 +314,8 @@ document.addEventListener("DOMContentLoaded", async () => {
                 displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
               }
             }
+          } else if (isSharedResourceHost) {
+            displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
             // For regular sites, just show the hostname from the matched URL
             displayUrl = matchedUrlObj.hostname;
@@ -304,6 +328,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         // Fallback to current URL if no match
         const urlObj = new URL(currentUrl);
         const isRepoSite = repositoryHosts.has(urlObj.hostname);
+        const isSharedResourceHost = sharedResourceHosts.has(urlObj.hostname);
 
         if (isRepoSite) {
           // For repo sites, extract the domain and first two path segments (user/repo)
@@ -313,6 +338,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else {
             displayUrl = urlObj.hostname + urlObj.pathname;
           }
+        } else if (isSharedResourceHost) {
+          displayUrl = urlObj.hostname + urlObj.pathname;
         } else {
           // For regular sites, just show the hostname
           displayUrl = urlObj.hostname;

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -15,6 +15,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   const warningPageUrl = browserAPI.runtime.getURL("pub/warning-page.html");
   const settingsPageUrl = browserAPI.runtime.getURL("pub/settings-page.html");
   const welcomePageUrl = browserAPI.runtime.getURL("pub/welcome-page.html");
+  const repositoryHosts = new Set([
+    "github.com",
+    "gitlab.com",
+    "codeberg.org",
+    "sourceforge.net",
+  ]);
   let fmhyLinkContext = null;
 
   fmhyResourceLink.addEventListener("click", async (event) => {
@@ -261,15 +267,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         try {
           const matchedUrlObj = new URL(response.matchedUrl);
           const currentUrlObj = new URL(currentUrl);
-          const isRepoSite = [
-            "github.com",
-            "gitlab.com",
-            "sourceforge.net",
-          ].some(
-            (domain) =>
-              matchedUrlObj.hostname === domain ||
-              matchedUrlObj.hostname.endsWith("." + domain)
-          );
+          const isRepoSite = repositoryHosts.has(matchedUrlObj.hostname);
 
           if (isRepoSite) {
             // For repo sites, extract the domain and path parts that were matched
@@ -305,10 +303,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       } else {
         // Fallback to current URL if no match
         const urlObj = new URL(currentUrl);
-        const isRepoSite = ["github.com", "gitlab.com", "sourceforge.net"].some(
-          (domain) =>
-            urlObj.hostname === domain || urlObj.hostname.endsWith("." + domain)
-        );
+        const isRepoSite = repositoryHosts.has(urlObj.hostname);
 
         if (isRepoSite) {
           // For repo sites, extract the domain and first two path segments (user/repo)

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -7,6 +7,26 @@ function formatHostAndPath(urlObj) {
   );
 }
 
+function renderTextWithLinks(container, text) {
+  container.replaceChildren();
+  const urlRegex = /https?:\/\/[^\s]+/g;
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(urlRegex)) {
+    container.append(document.createTextNode(text.slice(lastIndex, match.index)));
+    const url = match[0];
+    const link = document.createElement("a");
+    link.href = url;
+    link.textContent = url;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    container.append(link);
+    lastIndex = match.index + url.length;
+  }
+
+  container.append(document.createTextNode(text.slice(lastIndex)));
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   console.log("Popup loaded, preparing to check site status...");
 
@@ -401,10 +421,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // Handle reason display in dedicated container
     if (reason && (status === "unsafe" || status === "potentially_unsafe")) {
-      // Convert URLs to clickable links
-      const urlRegex = /(https?:\/\/[^\s]+)/g;
-      const formattedReason = reason.replace(urlRegex, '<a href="$1" target="_blank">$1</a>');
-      reasonContent.innerHTML = formattedReason;
+      renderTextWithLinks(reasonContent, reason);
       reasonContainer.classList.add("visible");
     } else {
       reasonContainer.classList.remove("visible");

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -317,8 +317,9 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, just show the hostname from the matched URL
-            displayUrl = matchedUrlObj.hostname;
+            // Preserve a canonical FMHY resource path without a trailing slash.
+            const matchedPath = matchedUrlObj.pathname.replace(/\/+$/, "");
+            displayUrl = matchedUrlObj.hostname + matchedPath;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -1,5 +1,10 @@
 function formatHostAndPath(urlObj) {
-  return urlObj.hostname + urlObj.pathname.replace(/\/+$/, "");
+  return (
+    urlObj.hostname +
+    urlObj.pathname.replace(/\/+$/, "") +
+    urlObj.search +
+    urlObj.hash
+  );
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -29,6 +34,18 @@ document.addEventListener("DOMContentLoaded", async () => {
     "github.com",
     "gist.github.com",
     "raw.githubusercontent.com",
+    "greasyfork.org",
+    "youtube.com",
+    "chromewebstore.google.com",
+    "colab.research.google.com",
+    "modrinth.com",
+    "f-droid.org",
+    "xdaforums.com",
+    "start.me",
+    "sites.google.com",
+    "matrix.to",
+    "codepen.io",
+    "vk.com",
     "gitlab.com",
     "codeberg.org",
     "sourceforge.net",

--- a/test-builds/firefox/pub/index.js
+++ b/test-builds/firefox/pub/index.js
@@ -317,8 +317,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           } else if (isSharedResourceHost) {
             displayUrl = matchedUrlObj.hostname + matchedUrlObj.pathname;
           } else {
-            // For regular sites, just show the hostname from the matched URL
-            displayUrl = matchedUrlObj.hostname;
+            // For regular sites, show the hostname currently being visited
+            displayUrl = currentUrlObj.hostname;
           }
         } catch (e) {
           console.error("Error formatting matched URL:", e);

--- a/test-builds/firefox/pub/warning-page.js
+++ b/test-builds/firefox/pub/warning-page.js
@@ -11,15 +11,29 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Display reason for unsafe site - prefer URL parameter, fallback to storage
   let reason = reasonFromUrl ? decodeURIComponent(reasonFromUrl) : null;
 
-  // Helper function to convert URLs to clickable links
-  function formatReasonWithLinks(text) {
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
-    return text.replace(urlRegex, '<a href="$1" target="_blank">$1</a>');
+  function renderTextWithLinks(container, text) {
+    container.replaceChildren();
+    const urlRegex = /https?:\/\/[^\s]+/g;
+    let lastIndex = 0;
+
+    for (const match of text.matchAll(urlRegex)) {
+      container.append(document.createTextNode(text.slice(lastIndex, match.index)));
+      const url = match[0];
+      const link = document.createElement("a");
+      link.href = url;
+      link.textContent = url;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      container.append(link);
+      lastIndex = match.index + url.length;
+    }
+
+    container.append(document.createTextNode(text.slice(lastIndex)));
   }
 
   if (reason) {
     console.log("Reason provided via URL parameter");
-    document.getElementById("reasonText").innerHTML = formatReasonWithLinks(reason);
+    renderTextWithLinks(document.getElementById("reasonText"), reason);
     document.getElementById("reasonContainer").style.display = "block";
   } else {
     // Fallback: try to fetch from storage
@@ -52,7 +66,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         console.log("Found reason:", reason ? "yes" : "no");
 
         if (reason) {
-          document.getElementById("reasonText").innerHTML = formatReasonWithLinks(reason);
+          renderTextWithLinks(document.getElementById("reasonText"), reason);
           document.getElementById("reasonContainer").style.display = "block";
         }
       } else {

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -393,3 +393,18 @@ test("the popup preserves paths for every shared resource host", () => {
     /displayUrl = matchedUrlObj\.hostname \+ matchedUrlObj\.pathname/,
   );
 });
+
+test("path-specific unsafe reasons also update the toolbar icon", () => {
+  assert.match(
+    backgroundScript,
+    /async function checkSiteAndUpdatePageAction\(tabId, url\)/,
+  );
+  assert.match(
+    backgroundScript,
+    /if \(status === "no_data" && await getReasonForUrl\(url\)\) \{\s*status = "unsafe";/,
+  );
+  assert.match(
+    backgroundScript,
+    /updatePageAction\(status, tabId\);/,
+  );
+});

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -150,3 +150,27 @@ test("shared-host passwords require an exact resource URL", () => {
     /getPasswordForDomain\(domain, url\)/,
   );
 });
+
+test("path-specific unsafe reasons preserve the repository path", () => {
+  const getReasonKeyForUrl = loadFunction(
+    backgroundScript,
+    "getReasonKeyForUrl",
+  );
+
+  assert.equal(
+    getReasonKeyForUrl(
+      "https://github.com/FVision8/FVReleases/releases?tab=readme#downloads",
+    ),
+    "github.com/fvision8/fvreleases/releases",
+  );
+  assert.equal(getReasonKeyForUrl("https://linktr.ee/flixvision/"), "linktr.ee/flixvision");
+  assert.equal(getReasonKeyForUrl("https://github.com/"), null);
+});
+
+test("path-specific reasons can classify otherwise unmatched URLs", () => {
+  assert.match(backgroundScript, /const pathSpecificReason = await getReasonForUrl\(url\)/);
+  assert.match(
+    backgroundScript,
+    /if \(status === "no_data" && pathSpecificReason\)/,
+  );
+});

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -19,6 +19,10 @@ const popupScript = fs.readFileSync(
   path.join(__dirname, "..", "src", "pub", "index.js"),
   "utf8",
 );
+const warningPageScript = fs.readFileSync(
+  path.join(__dirname, "..", "src", "pub", "warning-page.js"),
+  "utf8",
+);
 const fmhyHighlightScriptPath = path.join(
   __dirname,
   "..",
@@ -160,6 +164,39 @@ test("Markdown autolinks are extracted without angle brackets", () => {
     extractUrlsFromMarkdown("* <https://rentry.co/m2hkqhwb> - Mirror details"),
     ["https://rentry.co/m2hkqhwb"],
   );
+});
+
+test("filter-list regexes require URL and hostname boundaries", () => {
+  const generateRegexFromList = loadFunction(
+    backgroundScript,
+    "generateRegexFromList",
+  );
+  const urlRegex = generateRegexFromList([
+    "https://github.com/fvision8/fvreleases",
+  ]);
+  const hostnameRegex = generateRegexFromList(["unsafe.example"]);
+  const emptyRegex = generateRegexFromList([]);
+
+  assert.equal(urlRegex.test("https://github.com/fvision8/fvreleases"), true);
+  assert.equal(urlRegex.test("https://github.com/fvision8/fvreleases/app"), true);
+  assert.equal(urlRegex.test("https://github.com/fvision8/fvreleases-copy"), false);
+  assert.equal(urlRegex.test("https://github.com.evil/fvision8/fvreleases"), false);
+  assert.equal(hostnameRegex.test("unsafe.example"), true);
+  assert.equal(hostnameRegex.test("sub.unsafe.example"), true);
+  assert.equal(hostnameRegex.test("notunsafe.example"), false);
+  assert.equal(emptyRegex.test("https://anything.example"), false);
+});
+
+test("unsafe reasons are rendered without interpolating remote text as HTML", () => {
+  assert.match(popupScript, /function renderTextWithLinks\(/);
+  assert.match(warningPageScript, /function renderTextWithLinks\(/);
+  assert.match(contentScript, /function setUnsafeBadgeContent\(/);
+  assert.doesNotMatch(popupScript, /reasonContent\.innerHTML/);
+  assert.doesNotMatch(warningPageScript, /reasonText.*\.innerHTML|\.innerHTML.*reasonText/);
+  assert.doesNotMatch(contentScript, /badge\.innerHTML/);
+  assert.match(popupScript, /link\.textContent = url/);
+  assert.match(warningPageScript, /link\.textContent = url/);
+  assert.match(contentScript, /document\.createTextNode/);
 });
 
 test("root-only popup labels omit their trailing slash", () => {

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -52,6 +52,36 @@ function loadFunction(source, name) {
   throw new Error(`Could not read ${name}`);
 }
 
+function loadFunctionWithDependencies(source, name, dependencies) {
+  const fn = loadFunction(source, name);
+  return Function(
+    ...Object.keys(dependencies),
+    `return (${fn.toString()});`,
+  )(...Object.values(dependencies));
+}
+
+const sharedResourceHosts = new Set([
+  "github.com",
+  "raw.githubusercontent.com",
+  "gitlab.com",
+  "codeberg.org",
+  "sourceforge.net",
+  "rentry.co",
+  "rentry.org",
+  "pastebin.com",
+  "archive.org",
+  "drive.google.com",
+  "docs.google.com",
+  "discord.com",
+  "discord.gg",
+  "t.me",
+  "mega.nz",
+  "mediafire.com",
+  "gofile.io",
+  "pixeldrain.com",
+  "huggingface.co",
+]);
+
 test("processed link tracking can be reset after settings change", () => {
   assert.match(contentScript, /let processedLinks = new WeakSet\(\);/);
   assert.match(contentScript, /processedLinks = new WeakSet\(\);/);
@@ -188,4 +218,144 @@ test("the popup uses the neutral icon when a site is not in FMHY", () => {
     popupScript,
     /statusIcon\.alt = status === "no_data" \? "Not listed in FMHY" : "Site status"/,
   );
+});
+
+test("shared hosts require the same path-bound resource", () => {
+  const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
+  const isSharedResourceHost = loadFunctionWithDependencies(
+    backgroundScript,
+    "isSharedResourceHost",
+    { sharedResourceHosts },
+  );
+  const urlMatchesListedResource = loadFunctionWithDependencies(
+    backgroundScript,
+    "urlMatchesListedResource",
+    { normalizeUrl, isSharedResourceHost },
+  );
+
+  assert.equal(
+    urlMatchesListedResource(
+      "https://github.com/fmhy/FMHY-SafeGuard/releases",
+      "https://github.com/fmhy/FMHY-SafeGuard",
+    ),
+    true,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://github.com/fmhy/FMHYFilterlist",
+      "https://github.com/fmhy/FMHY-SafeGuard",
+    ),
+    false,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://github.com/",
+      "https://github.com/fmhy/FMHY-SafeGuard",
+    ),
+    false,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://codeberg.org/example/tool/releases",
+      "https://codeberg.org/example/tool",
+    ),
+    true,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://rentry.co/another-page",
+      "https://rentry.co/fmhy",
+    ),
+    false,
+  );
+});
+
+test("normal subdomains only inherit the matching listed path", () => {
+  const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
+  const isSharedResourceHost = loadFunctionWithDependencies(
+    backgroundScript,
+    "isSharedResourceHost",
+    { sharedResourceHosts },
+  );
+  const urlMatchesListedResource = loadFunctionWithDependencies(
+    backgroundScript,
+    "urlMatchesListedResource",
+    { normalizeUrl, isSharedResourceHost },
+  );
+
+  assert.equal(
+    urlMatchesListedResource(
+      "https://auth.ente.com/auth",
+      "https://ente.com/auth/",
+    ),
+    true,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://auth.ente.com/photos",
+      "https://ente.com/auth/",
+    ),
+    false,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://rentry.co/",
+      "https://rentry.co/fmhy",
+    ),
+    false,
+  );
+});
+
+test("status matching isolates shared resources and recognizes matching subdomains", () => {
+  const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
+  const isSharedResourceHost = loadFunctionWithDependencies(
+    backgroundScript,
+    "isSharedResourceHost",
+    { sharedResourceHosts },
+  );
+  const urlMatchesListedResource = loadFunctionWithDependencies(
+    backgroundScript,
+    "urlMatchesListedResource",
+    { normalizeUrl, isSharedResourceHost },
+  );
+  const getStatusFromLists = loadFunctionWithDependencies(
+    backgroundScript,
+    "getStatusFromLists",
+    {
+      userTrustedDomains: new Set(),
+      userUntrustedDomains: new Set(),
+      isSharedResourceHost,
+      urlMatchesListedResource,
+      unsafeSitesRegex: null,
+      potentiallyUnsafeSitesRegex: null,
+      fmhySitesRegex: null,
+      starredSites: [
+        "https://github.com/fmhy/FMHY-SafeGuard",
+        "https://ente.com/auth",
+        "https://mullvad.net",
+      ],
+      safeSites: ["https://github.com/fmhy/FMHYFilterlist"],
+      base64StarredLinks: [],
+      base64DecodedLinks: [],
+      unsafeHostnamesRegex: null,
+      potentiallyUnsafeHostnamesRegex: null,
+    },
+  );
+
+  assert.equal(getStatusFromLists("https://github.com/"), "no_data");
+  assert.equal(
+    getStatusFromLists("https://github.com/fmhy/FMHY-SafeGuard/releases"),
+    "starred",
+  );
+  assert.equal(
+    getStatusFromLists("https://github.com/fmhy/FMHYFilterlist/issues"),
+    "safe",
+  );
+  assert.equal(
+    getStatusFromLists("https://github.com/fmhy/unlisted-repository"),
+    "no_data",
+  );
+  assert.equal(getStatusFromLists("https://auth.ente.com/auth"), "starred");
+  assert.equal(getStatusFromLists("https://auth.ente.com/photos"), "no_data");
+  assert.equal(getStatusFromLists("https://mullvad.net/en"), "starred");
 });

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -127,3 +127,26 @@ test("opening an FMHY resource highlights its matching guide line", () => {
   assert.match(chromiumManifest, /js\/fmhy-highlight\.js/);
   assert.match(firefoxManifest, /js\/fmhy-highlight\.js/);
 });
+
+test("FMHY passwords and invite codes match the current guide", () => {
+  assert.match(backgroundScript, /"steamrip\.com": "steamrip\.com"/);
+  assert.match(backgroundScript, /"iptv\.watchott\.ru": "FREE-MEDIA"/);
+  assert.match(
+    backgroundScript,
+    /"https:\/\/rentry\.co\/fmhyb64#gnarly": "gnarly"/,
+  );
+  assert.match(
+    backgroundScript,
+    /"https:\/\/rentry\.co\/fmhyb64#alvro": "ByAlvRo"/,
+  );
+  assert.match(backgroundScript, /"ee3\.me": "mpgh"/);
+  assert.match(backgroundScript, /"rips\.cc": "1hack"/);
+});
+
+test("shared-host passwords require an exact resource URL", () => {
+  assert.doesNotMatch(backgroundScript, /"rentry\.co":/);
+  assert.match(
+    backgroundScript,
+    /getPasswordForDomain\(domain, url\)/,
+  );
+});

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -374,3 +374,22 @@ test("the popup preserves Codeberg owner and repository names", () => {
     /displayUrl = `\$\{matchedUrlObj\.hostname\}\/\$\{pathParts\[0\]\}\/\$\{pathParts\[1\]\}`/,
   );
 });
+
+test("the popup preserves paths for every shared resource host", () => {
+  const backgroundHosts = backgroundScript.match(
+    /const sharedResourceHosts = new Set\(\[([\s\S]*?)\]\);/,
+  )[1].match(/"([^"]+)"/g);
+  const popupHosts = popupScript.match(
+    /const sharedResourceHosts = new Set\(\[([\s\S]*?)\]\);/,
+  )[1].match(/"([^"]+)"/g);
+
+  assert.deepEqual(popupHosts, backgroundHosts);
+  assert.match(
+    popupScript,
+    /sharedResourceHosts\.has\(matchedUrlObj\.hostname\)/,
+  );
+  assert.match(
+    popupScript,
+    /displayUrl = matchedUrlObj\.hostname \+ matchedUrlObj\.pathname/,
+  );
+});

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -62,6 +62,7 @@ function loadFunctionWithDependencies(source, name, dependencies) {
 
 const sharedResourceHosts = new Set([
   "github.com",
+  "gist.github.com",
   "raw.githubusercontent.com",
   "gitlab.com",
   "codeberg.org",
@@ -121,6 +122,31 @@ test("all bold links on a starred guide line are treated as starred", () => {
     "https://first.example/",
     "https://second.example/",
   ]);
+});
+
+test("unbolded alternatives on a starred guide line are also starred", () => {
+  const extractStarredUrlsFromMarkdown = loadFunction(
+    backgroundScript,
+    "extractStarredUrlsFromMarkdown",
+  );
+  const markdown =
+    "* ⭐ **[GitHub Gists](https://gist.github.com/)** or [GitLab Snippets](https://docs.gitlab.com/user/snippets/) - Multi-Syntax / [Related](https://related.example/)";
+
+  assert.deepEqual(extractStarredUrlsFromMarkdown(markdown), [
+    "https://gist.github.com/",
+    "https://docs.gitlab.com/user/snippets/",
+  ]);
+});
+
+test("root-only popup labels omit their trailing slash", () => {
+  const formatHostAndPath = loadFunction(popupScript, "formatHostAndPath");
+
+  assert.equal(formatHostAndPath(new URL("https://github.com/")), "github.com");
+  assert.equal(formatHostAndPath(new URL("https://rentry.co/")), "rentry.co");
+  assert.equal(
+    formatHostAndPath(new URL("https://docs.gitlab.com/user/snippets/")),
+    "docs.gitlab.com/user/snippets",
+  );
 });
 
 test("guide resources map to their FMHY page section", () => {
@@ -276,6 +302,20 @@ test("shared hosts require the same path-bound resource", () => {
     ),
     false,
   );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://gist.github.com/starred",
+      "https://gist.github.com/",
+    ),
+    true,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://gist.github.com/example/dangerous-gist",
+      "https://gist.github.com/",
+    ),
+    false,
+  );
 });
 
 test("normal subdomains only inherit the matching listed path", () => {
@@ -346,6 +386,8 @@ test("status matching isolates shared resources and recognizes matching subdomai
       fmhySitesRegex: null,
       starredSites: [
         "https://github.com/fmhy/FMHY-SafeGuard",
+        "https://gist.github.com/",
+        "https://docs.gitlab.com/user/snippets/",
         "https://ente.com/auth",
         "https://mullvad.net",
       ],
@@ -373,6 +415,15 @@ test("status matching isolates shared resources and recognizes matching subdomai
   assert.equal(getStatusFromLists("https://auth.ente.com/auth"), "starred");
   assert.equal(getStatusFromLists("https://auth.ente.com/login"), "starred");
   assert.equal(getStatusFromLists("https://auth.ente.com/photos"), "no_data");
+  assert.equal(getStatusFromLists("https://gist.github.com/starred"), "starred");
+  assert.equal(
+    getStatusFromLists("https://gist.github.com/example/dangerous-gist"),
+    "no_data",
+  );
+  assert.equal(
+    getStatusFromLists("https://docs.gitlab.com/user/snippets/"),
+    "starred",
+  );
   assert.equal(getStatusFromLists("https://mullvad.net/en"), "starred");
 });
 
@@ -407,7 +458,7 @@ test("the popup preserves paths for every shared resource host", () => {
   );
   assert.match(
     popupScript,
-    /displayUrl = matchedUrlObj\.hostname \+ matchedUrlObj\.pathname/,
+    /displayUrl = formatHostAndPath\(matchedUrlObj\)/,
   );
 });
 
@@ -438,13 +489,8 @@ test("the toolbar does not inherit root status on shared hosts", () => {
 });
 
 test("the popup preserves canonical paths for ordinary FMHY resources", () => {
-  assert.ok(
-    popupScript.includes(
-      'const matchedPath = matchedUrlObj.pathname.replace(/\\/+$/, "");',
-    ),
-  );
   assert.match(
     popupScript,
-    /displayUrl = matchedUrlObj\.hostname \+ matchedPath;/,
+    /displayUrl = formatHostAndPath\(matchedUrlObj\);/,
   );
 });

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -64,6 +64,18 @@ const sharedResourceHosts = new Set([
   "github.com",
   "gist.github.com",
   "raw.githubusercontent.com",
+  "greasyfork.org",
+  "youtube.com",
+  "chromewebstore.google.com",
+  "colab.research.google.com",
+  "modrinth.com",
+  "f-droid.org",
+  "xdaforums.com",
+  "start.me",
+  "sites.google.com",
+  "matrix.to",
+  "codepen.io",
+  "vk.com",
   "gitlab.com",
   "codeberg.org",
   "sourceforge.net",
@@ -249,6 +261,11 @@ test("the popup uses the neutral icon when a site is not in FMHY", () => {
 
 test("shared hosts require the same path-bound resource", () => {
   const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
+  const normalizeResourceUrl = loadFunctionWithDependencies(
+    backgroundScript,
+    "normalizeResourceUrl",
+    { normalizeUrl },
+  );
   const isSharedResourceHost = loadFunctionWithDependencies(
     backgroundScript,
     "isSharedResourceHost",
@@ -257,7 +274,7 @@ test("shared hosts require the same path-bound resource", () => {
   const urlMatchesListedResource = loadFunctionWithDependencies(
     backgroundScript,
     "urlMatchesListedResource",
-    { normalizeUrl, isSharedResourceHost },
+    { normalizeResourceUrl, isSharedResourceHost },
   );
 
   assert.equal(
@@ -316,10 +333,50 @@ test("shared hosts require the same path-bound resource", () => {
     ),
     false,
   );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://www.youtube.com/watch?v=listed&t=30",
+      "https://www.youtube.com/watch?v=listed",
+    ),
+    true,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://www.youtube.com/watch?v=unlisted",
+      "https://www.youtube.com/watch?v=listed",
+    ),
+    false,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://matrix.to/#/#listed:matrix.org",
+      "https://matrix.to/#/#listed:matrix.org",
+    ),
+    true,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://matrix.to/#/#other:matrix.org",
+      "https://matrix.to/#/#listed:matrix.org",
+    ),
+    false,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://github.com/fmhy/FMHY-SafeGuard",
+      "https://github.com/fmhy/FMHY-SafeGuard#readme",
+    ),
+    true,
+  );
 });
 
 test("normal subdomains only inherit the matching listed path", () => {
   const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
+  const normalizeResourceUrl = loadFunctionWithDependencies(
+    backgroundScript,
+    "normalizeResourceUrl",
+    { normalizeUrl },
+  );
   const isSharedResourceHost = loadFunctionWithDependencies(
     backgroundScript,
     "isSharedResourceHost",
@@ -328,7 +385,7 @@ test("normal subdomains only inherit the matching listed path", () => {
   const urlMatchesListedResource = loadFunctionWithDependencies(
     backgroundScript,
     "urlMatchesListedResource",
-    { normalizeUrl, isSharedResourceHost },
+    { normalizeResourceUrl, isSharedResourceHost },
   );
 
   assert.equal(
@@ -363,6 +420,11 @@ test("normal subdomains only inherit the matching listed path", () => {
 
 test("status matching isolates shared resources and recognizes matching subdomains", () => {
   const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
+  const normalizeResourceUrl = loadFunctionWithDependencies(
+    backgroundScript,
+    "normalizeResourceUrl",
+    { normalizeUrl },
+  );
   const isSharedResourceHost = loadFunctionWithDependencies(
     backgroundScript,
     "isSharedResourceHost",
@@ -371,7 +433,7 @@ test("status matching isolates shared resources and recognizes matching subdomai
   const urlMatchesListedResource = loadFunctionWithDependencies(
     backgroundScript,
     "urlMatchesListedResource",
-    { normalizeUrl, isSharedResourceHost },
+    { normalizeResourceUrl, isSharedResourceHost },
   );
   const getStatusFromLists = loadFunctionWithDependencies(
     backgroundScript,
@@ -452,6 +514,22 @@ test("the popup preserves paths for every shared resource host", () => {
 
   assert.deepEqual(popupHosts, backgroundHosts);
   assert.ok(backgroundHosts.includes('"linktr.ee"'));
+  for (const host of [
+    '"greasyfork.org"',
+    '"youtube.com"',
+    '"chromewebstore.google.com"',
+    '"colab.research.google.com"',
+    '"modrinth.com"',
+    '"f-droid.org"',
+    '"xdaforums.com"',
+    '"start.me"',
+    '"sites.google.com"',
+    '"matrix.to"',
+    '"codepen.io"',
+    '"vk.com"',
+  ]) {
+    assert.ok(backgroundHosts.includes(host));
+  }
   assert.match(
     popupScript,
     /sharedResourceHosts\.has\(matchedUrlObj\.hostname\)/,
@@ -474,6 +552,25 @@ test("path-specific unsafe reasons also update the toolbar icon", () => {
   assert.match(
     backgroundScript,
     /updatePageAction\(status, tabId\);/,
+  );
+});
+
+test("live resource data preserves query and fragment identities", () => {
+  assert.match(
+    backgroundScript,
+    /allUrls\.map\(\(url\) => normalizeResourceUrl\(url\.trim\(\)\)\)/,
+  );
+  assert.match(
+    backgroundScript,
+    /const resourceUrl = normalizeResourceUrl\(url\);/,
+  );
+  assert.match(
+    backgroundScript,
+    /urlMatchesListedResource\(resourceUrl, listedUrl\)/,
+  );
+  assert.match(
+    backgroundScript,
+    /storedData\.resourceIdentityVersion === resourceIdentityVersion/,
   );
 });
 

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -387,7 +387,10 @@ test("shared hosts require the same path-bound resource", () => {
 test("cross-domain redirects retain the listed origin status per tab", () => {
   assert.match(chromiumManifest, /"webNavigation"/);
   assert.match(firefoxManifest, /"webNavigation"/);
-  assert.match(backgroundScript, /webNavigation\.onBeforeRedirect\.addListener/);
+  assert.match(backgroundScript, /webNavigation\?\.onBeforeRedirect\?\.addListener/);
+  assert.match(backgroundScript, /webNavigation\?\.onBeforeNavigate\?\.addListener/);
+  assert.match(backgroundScript, /webNavigation\?\.onCommitted\?\.addListener/);
+  assert.match(backgroundScript, /transitionQualifiers\?\.includes\("server_redirect"\)/);
   assert.match(backgroundScript, /redirectOrigins\.set\(details\.tabId/);
   assert.match(backgroundScript, /getRedirectOrigin\(message\.tabId, url\)/);
   assert.match(popupScript, /tabId: activeTab\.id/);

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -408,3 +408,10 @@ test("path-specific unsafe reasons also update the toolbar icon", () => {
     /updatePageAction\(status, tabId\);/,
   );
 });
+
+test("the popup identifies the current hostname for inherited domain status", () => {
+  assert.match(
+    popupScript,
+    /\/\/ For regular sites, show the hostname currently being visited\s*displayUrl = currentUrlObj\.hostname;/,
+  );
+});

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -174,3 +174,18 @@ test("path-specific reasons can classify otherwise unmatched URLs", () => {
     /if \(status === "no_data" && pathSpecificReason\)/,
   );
 });
+
+test("the popup uses the neutral icon when a site is not in FMHY", () => {
+  assert.match(
+    popupScript,
+    /no_data: "\.\.\/res\/icons\/default\.png"/,
+  );
+  assert.match(
+    popupScript,
+    /unknown: "\.\.\/res\/icons\/default\.png"/,
+  );
+  assert.match(
+    popupScript,
+    /statusIcon\.alt = status === "no_data" \? "Not listed in FMHY" : "Site status"/,
+  );
+});

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -292,6 +292,13 @@ test("normal subdomains only inherit the matching listed path", () => {
   );
   assert.equal(
     urlMatchesListedResource(
+      "https://auth.ente.com/login",
+      "https://ente.com/auth/",
+    ),
+    true,
+  );
+  assert.equal(
+    urlMatchesListedResource(
       "https://auth.ente.com/photos",
       "https://ente.com/auth/",
     ),
@@ -356,6 +363,7 @@ test("status matching isolates shared resources and recognizes matching subdomai
     "no_data",
   );
   assert.equal(getStatusFromLists("https://auth.ente.com/auth"), "starred");
+  assert.equal(getStatusFromLists("https://auth.ente.com/login"), "starred");
   assert.equal(getStatusFromLists("https://auth.ente.com/photos"), "no_data");
   assert.equal(getStatusFromLists("https://mullvad.net/en"), "starred");
 });
@@ -406,5 +414,17 @@ test("path-specific unsafe reasons also update the toolbar icon", () => {
   assert.match(
     backgroundScript,
     /updatePageAction\(status, tabId\);/,
+  );
+});
+
+test("the popup preserves canonical paths for ordinary FMHY resources", () => {
+  assert.ok(
+    popupScript.includes(
+      'const matchedPath = matchedUrlObj.pathname.replace(/\\/+$/, "");',
+    ),
+  );
+  assert.match(
+    popupScript,
+    /displayUrl = matchedUrlObj\.hostname \+ matchedPath;/,
   );
 });

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -166,6 +166,13 @@ test("Markdown autolinks are extracted without angle brackets", () => {
   );
 });
 
+test("unsafe navigation is checked as soon as the tab URL changes", () => {
+  assert.match(
+    backgroundScript,
+    /tabs\.onUpdated\.addListener\(async \(tabId, changeInfo, tab\) => \{\s*if \(changeInfo\.url\) \{\s*await checkSiteAndUpdatePageAction\(tabId, changeInfo\.url\);\s*return;/,
+  );
+});
+
 test("filter-list regexes require URL and hostname boundaries", () => {
   const generateRegexFromList = loadFunction(
     backgroundScript,

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -387,9 +387,13 @@ test("shared hosts require the same path-bound resource", () => {
 test("cross-domain redirects retain the listed origin status per tab", () => {
   assert.match(chromiumManifest, /"webNavigation"/);
   assert.match(firefoxManifest, /"webNavigation"/);
+  assert.match(firefoxManifest, /"webRequest"/);
+  assert.match(firefoxManifest, /"host_permissions"\s*:\s*\[\s*"<all_urls>"/);
   assert.match(backgroundScript, /webNavigation\?\.onBeforeRedirect\?\.addListener/);
   assert.match(backgroundScript, /webNavigation\?\.onBeforeNavigate\?\.addListener/);
   assert.match(backgroundScript, /webNavigation\?\.onCommitted\?\.addListener/);
+  assert.match(backgroundScript, /webRequest\?\.onBeforeRedirect\?\.addListener/);
+  assert.match(backgroundScript, /types: \["main_frame"\]/);
   assert.match(backgroundScript, /transitionQualifiers\?\.includes\("server_redirect"\)/);
   assert.match(backgroundScript, /redirectOrigins\.set\(details\.tabId/);
   assert.match(backgroundScript, /getRedirectOrigin\(message\.tabId, url\)/);

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -150,6 +150,18 @@ test("unbolded alternatives on a starred guide line are also starred", () => {
   ]);
 });
 
+test("Markdown autolinks are extracted without angle brackets", () => {
+  const extractUrlsFromMarkdown = loadFunction(
+    backgroundScript,
+    "extractUrlsFromMarkdown",
+  );
+
+  assert.deepEqual(
+    extractUrlsFromMarkdown("* <https://rentry.co/m2hkqhwb> - Mirror details"),
+    ["https://rentry.co/m2hkqhwb"],
+  );
+});
+
 test("root-only popup labels omit their trailing slash", () => {
   const formatHostAndPath = loadFunction(popupScript, "formatHostAndPath");
 
@@ -175,6 +187,26 @@ test("guide resources map to their FMHY page section", () => {
   assert.deepEqual(
     extractFmhyResourceMap(markdown, "https://fmhy.net/privacy"),
     { "https://vpn.example/download": "https://fmhy.net/privacy#vpn-services" },
+  );
+});
+
+test("Markdown autolinks map to their FMHY page section", () => {
+  const extractFmhyResourceMap = loadFunction(
+    backgroundScript,
+    "extractFmhyResourceMap",
+  );
+  const markdown = [
+    "## Reading",
+    "### LibGen Mirrors",
+    "* <https://rentry.co/m2hkqhwb> - Differences between the mirrors",
+  ].join("\n");
+
+  assert.deepEqual(
+    extractFmhyResourceMap(markdown, "https://fmhy.net/storage"),
+    {
+      "https://rentry.co/m2hkqhwb":
+        "https://fmhy.net/storage#libgen-mirrors",
+    },
   );
 });
 

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -237,7 +237,7 @@ test("path-specific unsafe reasons preserve the repository path", () => {
 });
 
 test("path-specific reasons can classify otherwise unmatched URLs", () => {
-  assert.match(backgroundScript, /let pathSpecificReason = await getReasonForUrl\(url\)/);
+  assert.match(backgroundScript, /const pathSpecificReason = await getReasonForUrl\(url\)/);
   assert.match(
     backgroundScript,
     /if \(status === "no_data" && pathSpecificReason\)/,
@@ -384,48 +384,11 @@ test("shared hosts require the same path-bound resource", () => {
   );
 });
 
-test("cross-domain redirects retain the listed origin status per tab", () => {
-  assert.match(chromiumManifest, /"webNavigation"/);
-  assert.match(firefoxManifest, /"webNavigation"/);
-  assert.match(firefoxManifest, /"webRequest"/);
-  assert.match(firefoxManifest, /"host_permissions"\s*:\s*\[\s*"<all_urls>"/);
-  assert.match(backgroundScript, /webNavigation\?\.onBeforeRedirect\?\.addListener/);
-  assert.match(backgroundScript, /webNavigation\?\.onBeforeNavigate\?\.addListener/);
-  assert.match(backgroundScript, /webNavigation\?\.onCommitted\?\.addListener/);
-  assert.match(backgroundScript, /webRequest\?\.onBeforeRedirect\?\.addListener/);
-  assert.match(backgroundScript, /types: \["main_frame"\]/);
-  assert.match(backgroundScript, /transitionQualifiers\?\.includes\("server_redirect"\)/);
-  assert.match(backgroundScript, /redirectOrigins\.set\(details\.tabId/);
-  assert.match(backgroundScript, /getRedirectOrigin\(message\.tabId, url\)/);
-  assert.match(popupScript, /tabId: activeTab\.id/);
-
-  const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
-  const normalizeResourceUrl = loadFunctionWithDependencies(
-    backgroundScript,
-    "normalizeResourceUrl",
-    { normalizeUrl },
-  );
-  const redirectOrigins = new Map([
-    [
-      7,
-      {
-        originUrl: "https://alienflix.net/",
-        targetUrl: "https://hdtodayz.net/",
-        createdAt: Date.now(),
-      },
-    ],
-  ]);
-  const getRedirectOrigin = loadFunctionWithDependencies(
-    backgroundScript,
-    "getRedirectOrigin",
-    { redirectOrigins, normalizeResourceUrl },
-  );
-
-  assert.equal(
-    getRedirectOrigin(7, "https://hdtodayz.net/"),
-    "https://alienflix.net/",
-  );
-  assert.equal(getRedirectOrigin(7, "https://unrelated.example/"), null);
+test("cross-domain redirects do not inherit a source site's status", () => {
+  assert.doesNotMatch(chromiumManifest, /"webNavigation"/);
+  assert.doesNotMatch(firefoxManifest, /"webNavigation"|"webRequest"/);
+  assert.doesNotMatch(backgroundScript, /redirectOrigins|getRedirectOrigin/);
+  assert.doesNotMatch(popupScript, /tabId: activeTab\.id/);
 });
 
 test("normal subdomains only inherit the matching listed path", () => {
@@ -629,21 +592,6 @@ test("live resource data preserves query and fragment identities", () => {
   assert.match(
     backgroundScript,
     /storedData\.resourceIdentityVersion === resourceIdentityVersion/,
-  );
-});
-
-test("status checks wait for list initialization", () => {
-  assert.match(
-    backgroundScript,
-    /let initializationPromise = null;/,
-  );
-  assert.match(
-    backgroundScript,
-    /if \(initializationPromise\) await initializationPromise;/,
-  );
-  assert.match(
-    backgroundScript,
-    /initializationPromise = initializeExtension\(\);/,
   );
 });
 

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -625,6 +625,21 @@ test("live resource data preserves query and fragment identities", () => {
   );
 });
 
+test("status checks wait for list initialization", () => {
+  assert.match(
+    backgroundScript,
+    /let initializationPromise = null;/,
+  );
+  assert.match(
+    backgroundScript,
+    /if \(initializationPromise\) await initializationPromise;/,
+  );
+  assert.match(
+    backgroundScript,
+    /initializationPromise = initializeExtension\(\);/,
+  );
+});
+
 test("the toolbar does not inherit root status on shared hosts", () => {
   assert.match(
     backgroundScript,

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -408,10 +408,3 @@ test("path-specific unsafe reasons also update the toolbar icon", () => {
     /updatePageAction\(status, tabId\);/,
   );
 });
-
-test("the popup identifies the current hostname for inherited domain status", () => {
-  assert.match(
-    popupScript,
-    /\/\/ For regular sites, show the hostname currently being visited\s*displayUrl = currentUrlObj\.hostname;/,
-  );
-});

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -359,3 +359,18 @@ test("status matching isolates shared resources and recognizes matching subdomai
   assert.equal(getStatusFromLists("https://auth.ente.com/photos"), "no_data");
   assert.equal(getStatusFromLists("https://mullvad.net/en"), "starred");
 });
+
+test("the popup preserves Codeberg owner and repository names", () => {
+  assert.match(
+    popupScript,
+    /const repositoryHosts = new Set\(\[[\s\S]*"codeberg\.org"[\s\S]*\]\)/,
+  );
+  assert.match(
+    popupScript,
+    /repositoryHosts\.has\(matchedUrlObj\.hostname\)/,
+  );
+  assert.match(
+    popupScript,
+    /displayUrl = `\$\{matchedUrlObj\.hostname\}\/\$\{pathParts\[0\]\}\/\$\{pathParts\[1\]\}`/,
+  );
+});

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -66,6 +66,7 @@ const sharedResourceHosts = new Set([
   "gitlab.com",
   "codeberg.org",
   "sourceforge.net",
+  "linktr.ee",
   "rentry.co",
   "rentry.org",
   "pastebin.com",
@@ -268,6 +269,13 @@ test("shared hosts require the same path-bound resource", () => {
     ),
     false,
   );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://linktr.ee/flixvision",
+      "https://linktr.ee/another-profile",
+    ),
+    false,
+  );
 });
 
 test("normal subdomains only inherit the matching listed path", () => {
@@ -392,6 +400,7 @@ test("the popup preserves paths for every shared resource host", () => {
   )[1].match(/"([^"]+)"/g);
 
   assert.deepEqual(popupHosts, backgroundHosts);
+  assert.ok(backgroundHosts.includes('"linktr.ee"'));
   assert.match(
     popupScript,
     /sharedResourceHosts\.has\(matchedUrlObj\.hostname\)/,

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -426,6 +426,17 @@ test("path-specific unsafe reasons also update the toolbar icon", () => {
   );
 });
 
+test("the toolbar does not inherit root status on shared hosts", () => {
+  assert.match(
+    backgroundScript,
+    /const requiresResourcePath = normalizedUrl\s*\? isSharedResourceHost\(new URL\(normalizedUrl\)\.hostname\)\s*: false;/,
+  );
+  assert.match(
+    backgroundScript,
+    /if \(status === "no_data" && !requiresResourcePath\) \{\s*status = getStatusFromLists\(rootUrl\);/,
+  );
+});
+
 test("the popup preserves canonical paths for ordinary FMHY resources", () => {
   assert.ok(
     popupScript.includes(

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -237,7 +237,7 @@ test("path-specific unsafe reasons preserve the repository path", () => {
 });
 
 test("path-specific reasons can classify otherwise unmatched URLs", () => {
-  assert.match(backgroundScript, /const pathSpecificReason = await getReasonForUrl\(url\)/);
+  assert.match(backgroundScript, /let pathSpecificReason = await getReasonForUrl\(url\)/);
   assert.match(
     backgroundScript,
     /if \(status === "no_data" && pathSpecificReason\)/,
@@ -368,6 +368,57 @@ test("shared hosts require the same path-bound resource", () => {
     ),
     true,
   );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://greasyfork.org/en/scripts/453320-simple-sponsor-skipper",
+      "https://greasyfork.org/en/scripts/453320",
+    ),
+    true,
+  );
+  assert.equal(
+    urlMatchesListedResource(
+      "https://greasyfork.org/en/scripts/999999-unlisted-script",
+      "https://greasyfork.org/en/scripts/453320",
+    ),
+    false,
+  );
+});
+
+test("cross-domain redirects retain the listed origin status per tab", () => {
+  assert.match(chromiumManifest, /"webNavigation"/);
+  assert.match(firefoxManifest, /"webNavigation"/);
+  assert.match(backgroundScript, /webNavigation\.onBeforeRedirect\.addListener/);
+  assert.match(backgroundScript, /redirectOrigins\.set\(details\.tabId/);
+  assert.match(backgroundScript, /getRedirectOrigin\(message\.tabId, url\)/);
+  assert.match(popupScript, /tabId: activeTab\.id/);
+
+  const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
+  const normalizeResourceUrl = loadFunctionWithDependencies(
+    backgroundScript,
+    "normalizeResourceUrl",
+    { normalizeUrl },
+  );
+  const redirectOrigins = new Map([
+    [
+      7,
+      {
+        originUrl: "https://alienflix.net/",
+        targetUrl: "https://hdtodayz.net/",
+        createdAt: Date.now(),
+      },
+    ],
+  ]);
+  const getRedirectOrigin = loadFunctionWithDependencies(
+    backgroundScript,
+    "getRedirectOrigin",
+    { redirectOrigins, normalizeResourceUrl },
+  );
+
+  assert.equal(
+    getRedirectOrigin(7, "https://hdtodayz.net/"),
+    "https://alienflix.net/",
+  );
+  assert.equal(getRedirectOrigin(7, "https://unrelated.example/"), null);
 });
 
 test("normal subdomains only inherit the matching listed path", () => {

--- a/updates.json
+++ b/updates.json
@@ -3,8 +3,8 @@
     "{5d554479-7cc4-487f-bd25-d8fc67a42602}": {
       "updates": [
         {
-          "version": "1.3.7",
-          "update_link": "https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.7/FMHY-SafeGuard_v1.3.7.firefox.xpi"
+          "version": "1.3.8",
+          "update_link": "https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.8/FMHY-SafeGuard_v1.3.8.firefox.xpi"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- add missing FMHY passwords for SteamRIP, Watchott Live, Gnarly Repacks, and AlvRo
- correct the RIPS invite code while retaining the EE3 code
- match unsafe reasons by URL path for shared hosts such as GitHub and Linktree
- scope starred and safe status to the listed resource path on GitHub, GitLab, Codeberg, Rentry, Archive.org, file hosts, and similar shared services
- recognize matching subdomains and redirected paths such as Ente Auth without extending the status to sibling paths
- use the neutral not-in-wiki icon for unknown popup states instead of the branded SafeGuard icon
- keep Chrome and Firefox test builds synchronized with source

## Why

Shared-content hosts cannot safely inherit status at the domain level: one trusted repository, paste, note, or file must not mark sibling resources or the host root trusted. Matching now follows a one-way resource boundary: a listed path covers itself and descendants, while sibling paths remain unknown. Normal sites can still inherit a listed root or a matching parent-domain path.

The popup also previously used branded shield/check artwork when no FMHY data existed, which could be misread as a safe verdict. The neutral icon now makes the unknown state visually distinct.

## Validation

- `node --test` (15 tests passed)
- adversarial coverage for GitHub roots, sibling repositories, descendants, Codeberg, Rentry, Ente Auth, Mullvad, and path-specific unsafe reasons
- verified source and committed Chrome/Firefox test builds are byte-for-byte synchronized
- ran `git diff --check`

Closes #43
Closes #44