### PR TITLE
Release v1.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+#### **🐞 Bug Fixes**
+- Prevented page loads from repeatedly scanning the full FMHY resource list, eliminating the v1.3.8 CPU spike.
+
 ## v1.3.8 (07/12/2026)
 
 #### **🔧 Enhancements**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v1.3.9 (07/17/2026)
 
 #### **🐞 Bug Fixes**
 - Prevented page loads from repeatedly scanning the full FMHY resource list, eliminating the v1.3.8 CPU spike.

--- a/RELEASE.HEAD.md
+++ b/RELEASE.HEAD.md
@@ -1,6 +1,6 @@
-[Commits to main since this release](https://github.com/fmhy/FMHY-SafeGuard/compare/v1.3.8...main)
+[Commits to main since this release](https://github.com/fmhy/FMHY-SafeGuard/compare/v1.3.9...main)
 
 To install the developer build:
 
-- **Firefox**: Click [FMHY-SafeGuard_v1.3.8.firefox.signed.xpi](https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.8/FMHY-SafeGuard_v1.3.8.firefox.signed.xpi).
-- **Chromium**: Click [FMHY-SafeGuard_v1.3.8.chromium.zip](https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.8/FMHY-SafeGuard_v1.3.8.chromium.zip).
+- **Firefox**: Click [FMHY-SafeGuard_v1.3.9.firefox.signed.xpi](https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.9/FMHY-SafeGuard_v1.3.9.firefox.signed.xpi).
+- **Chromium**: Click [FMHY-SafeGuard_v1.3.9.chromium.zip](https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.9/FMHY-SafeGuard_v1.3.9.chromium.zip).

--- a/platform/chromium/manifest.json
+++ b/platform/chromium/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_extensionName__",
     "default_locale": "en",
     "author": "Kenneth Hendricks & contributors",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "icons": {
         "128": "res/ext_icon_144.png"
     },

--- a/platform/firefox/manifest.json
+++ b/platform/firefox/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_extensionName__",
     "default_locale": "en",
     "author": "Kenneth Hendricks & contributors",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "icons": {
         "128": "res/ext_icon_144.png"
     },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -127,12 +127,16 @@ let fmhySitesRegex = null;
 let fmhyHostnamesRegex = null; // Domain-only regex for FMHY sites
 let safeSites = [];
 let starredSites = [];
+let safeSiteIndex = new Map();
+let starredSiteIndex = new Map();
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
+const checkedTabUrls = new Map(); // Last status-checked URL per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
+let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -302,6 +306,8 @@ const base64SafeLinksEncoded = [
   "aHR0cHM6Ly9naXRodWIuY29tL0Nvc21pY1NjYWxlL1BTQkJOLURlZmluaXRpdmUtRW5nbGlzaC1QYXRjaA==",
 ];
 const base64DecodedLinks = base64SafeLinksEncoded.map(e => atob(e));
+const base64StarredSiteIndex = buildResourceIndex(base64StarredLinks);
+const base64SafeSiteIndex = buildResourceIndex(base64DecodedLinks);
 
 // List of search engines to check against
 const searchEngines = [
@@ -839,6 +845,53 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
   return true;
 }
 
+function buildResourceIndex(urls) {
+  const index = new Map();
+
+  for (const url of urls) {
+    const normalizedUrl = normalizeResourceUrl(url);
+    if (!normalizedUrl) continue;
+
+    const hostname = new URL(normalizedUrl).hostname
+      .replace(/^www\./, "")
+      .toLowerCase();
+    const resources = index.get(hostname) || [];
+    resources.push(normalizedUrl);
+    index.set(hostname, resources);
+  }
+
+  return index;
+}
+
+function findMatchingListedResource(currentUrl, resourceIndex) {
+  const normalizedUrl = normalizeResourceUrl(currentUrl);
+  if (!normalizedUrl) return undefined;
+
+  const hostname = new URL(normalizedUrl).hostname
+    .replace(/^www\./, "")
+    .toLowerCase();
+  const candidateHosts = [hostname];
+
+  // Normal sites can inherit a resource classification from a listed parent
+  // domain. Shared platforms must remain scoped to their exact hostname.
+  if (!isSharedResourceHost(hostname)) {
+    const labels = hostname.split(".");
+    for (let index = 1; index < labels.length - 1; index += 1) {
+      candidateHosts.push(labels.slice(index).join("."));
+    }
+  }
+
+  for (const candidateHost of candidateHosts) {
+    const resources = resourceIndex.get(candidateHost) || [];
+    const match = resources.find((listedUrl) =>
+      urlMatchesListedResource(normalizedUrl, listedUrl)
+    );
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
 function extractRootUrl(url) {
   if (!url) {
     console.warn("Received null or undefined URL for root extraction.");
@@ -979,6 +1032,7 @@ async function fetchFilterLists() {
       fmhyFilterCount: fmhySites.length,
       lastUpdated: new Date().toISOString(),
     });
+    checkedTabUrls.clear();
 
     console.log("Filter lists fetched and stored successfully.");
 
@@ -1022,6 +1076,8 @@ async function fetchSafeSites() {
     safeSites = [
       ...new Set(allUrls.map((url) => normalizeResourceUrl(url.trim()))),
     ].filter((url) => url !== null);
+    safeSiteIndex = buildResourceIndex(safeSites);
+    checkedTabUrls.clear();
 
     // Store safe sites for content script use
     await browserAPI.storage.local.set({
@@ -1064,6 +1120,8 @@ async function fetchStarredSites() {
           .filter((url) => url !== null)
       )
     );
+    starredSiteIndex = buildResourceIndex(starredSites);
+    checkedTabUrls.clear();
 
     await browserAPI.storage.local.set({
       starredSites,
@@ -1131,6 +1189,8 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
+  if (initializationPromise) await initializationPromise;
+
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1163,36 +1223,14 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   // First check the full URL
   status = getStatusFromLists(resourceUrl);
 
-  // If not found, try with trailing slash
-  if (
-    status === "no_data" &&
-    !requiresResourcePath &&
-    !normalizedUrl.endsWith("/")
-  ) {
-    status = getStatusFromLists(normalizedUrl + "/");
-    if (status !== "no_data") matchedUrl = normalizedUrl + "/";
-  }
-
-  // If not found, try without trailing slash
-  if (
-    status === "no_data" &&
-    !requiresResourcePath &&
-    normalizedUrl.endsWith("/")
-  ) {
-    status = getStatusFromLists(normalizedUrl.slice(0, -1));
-    if (status !== "no_data") matchedUrl = normalizedUrl.slice(0, -1);
-  }
-
   // If still no match, check the root URL
-  if (status === "no_data" && !requiresResourcePath) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    rootUrl !== resourceUrl
+  ) {
     status = getStatusFromLists(rootUrl);
     if (status !== "no_data") matchedUrl = rootUrl;
-
-    // Try root URL with trailing slash
-    if (status === "no_data" && !rootUrl.endsWith("/")) {
-      status = getStatusFromLists(rootUrl + "/");
-      if (status !== "no_data") matchedUrl = rootUrl + "/";
-    }
   }
 
   // A path-specific reason can classify a resource even when it is absent from
@@ -1301,6 +1339,8 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
+        if (initializationPromise) await initializationPromise;
+
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1344,17 +1384,25 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         } else if (fmhySitesRegex?.test(normalizedUrl)) {
           status = "fmhy";
           matchedUrl = normalizedUrl;
-        } else if ((matchedUrl = starredSites.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          starredSiteIndex,
+        ))) {
           status = "starred";
-        } else if ((matchedUrl = safeSites.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          safeSiteIndex,
+        ))) {
           status = "safe";
-        } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          base64StarredSiteIndex,
+        ))) {
           status = "starred";
-        } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          base64SafeSiteIndex,
+        ))) {
           status = "safe";
         }
 
@@ -1479,10 +1527,10 @@ function getStatusFromLists(url) {
     if (unsafeSitesRegex?.test(url)) return "unsafe";
     if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
     if (fmhySitesRegex?.test(url)) return "fmhy";
-    if (starredSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
-    if (safeSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
-    if (base64StarredLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
-    if (base64DecodedLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+    if (findMatchingListedResource(url, starredSiteIndex)) return "starred";
+    if (findMatchingListedResource(url, safeSiteIndex)) return "safe";
+    if (findMatchingListedResource(url, base64StarredSiteIndex)) return "starred";
+    if (findMatchingListedResource(url, base64SafeSiteIndex)) return "safe";
 
     if (requiresResourcePath) return "no_data";
 
@@ -1553,14 +1601,26 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
+function shouldCheckTabUrl(tabId, url) {
+  const normalizedUrl = normalizeResourceUrl(url) || url;
+  if (checkedTabUrls.get(tabId) === normalizedUrl) return false;
+
+  checkedTabUrls.set(tabId, normalizedUrl);
+  return true;
+}
+
 // Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-  if (changeInfo.url) {
+  if (changeInfo.url && shouldCheckTabUrl(tabId, changeInfo.url)) {
     await checkSiteAndUpdatePageAction(tabId, changeInfo.url);
     return;
   }
 
-  if (changeInfo.status === "complete" && tab.url) {
+  if (
+    changeInfo.status === "complete" &&
+    tab.url &&
+    shouldCheckTabUrl(tabId, tab.url)
+  ) {
     // Always check the site status
     await checkSiteAndUpdatePageAction(tabId, tab.url);
   }
@@ -1568,8 +1628,8 @@ browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
 browserAPI.tabs.onActivated.addListener(async (activeInfo) => {
   const tab = await browserAPI.tabs.get(activeInfo.tabId);
-  if (tab.url) {
-    checkSiteAndUpdatePageAction(tab.id, tab.url);
+  if (tab.url && shouldCheckTabUrl(tab.id, tab.url)) {
+    await checkSiteAndUpdatePageAction(tab.id, tab.url);
   }
 });
 
@@ -1584,6 +1644,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
+  checkedTabUrls.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 
@@ -1640,6 +1701,7 @@ async function loadUserDomains() {
 browserAPI.storage.onChanged.addListener((changes, area) => {
   if (area === "local") {
     if (changes.userTrustedDomains || changes.userUntrustedDomains) {
+      checkedTabUrls.clear();
       loadUserDomains().then(() => {
         console.log("User domains reloaded after settings change");
       });
@@ -1725,6 +1787,7 @@ async function initializeExtension() {
           storedData.starredSites.length > 0
         ) {
           starredSites = storedData.starredSites;
+          starredSiteIndex = buildResourceIndex(starredSites);
           console.log(
             `Loaded ${starredSites.length} starred sites from storage`
           );
@@ -1742,6 +1805,7 @@ async function initializeExtension() {
           storedData.safeSiteList.length > 0
         ) {
           safeSites = storedData.safeSiteList;
+          safeSiteIndex = buildResourceIndex(safeSites);
           console.log(`Loaded ${safeSites.length} safe sites from storage`);
           const hasLegacyAnchors = Object.values(fmhyResourceMap).some(
             (fmhyUrl) => fmhyUrl.includes("#-")
@@ -1836,4 +1900,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializeExtension();
+initializationPromise = initializeExtension();

--- a/test-builds/chrome/js/background.js
+++ b/test-builds/chrome/js/background.js
@@ -127,12 +127,16 @@ let fmhySitesRegex = null;
 let fmhyHostnamesRegex = null; // Domain-only regex for FMHY sites
 let safeSites = [];
 let starredSites = [];
+let safeSiteIndex = new Map();
+let starredSiteIndex = new Map();
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
+const checkedTabUrls = new Map(); // Last status-checked URL per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
+let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -302,6 +306,8 @@ const base64SafeLinksEncoded = [
   "aHR0cHM6Ly9naXRodWIuY29tL0Nvc21pY1NjYWxlL1BTQkJOLURlZmluaXRpdmUtRW5nbGlzaC1QYXRjaA==",
 ];
 const base64DecodedLinks = base64SafeLinksEncoded.map(e => atob(e));
+const base64StarredSiteIndex = buildResourceIndex(base64StarredLinks);
+const base64SafeSiteIndex = buildResourceIndex(base64DecodedLinks);
 
 // List of search engines to check against
 const searchEngines = [
@@ -839,6 +845,53 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
   return true;
 }
 
+function buildResourceIndex(urls) {
+  const index = new Map();
+
+  for (const url of urls) {
+    const normalizedUrl = normalizeResourceUrl(url);
+    if (!normalizedUrl) continue;
+
+    const hostname = new URL(normalizedUrl).hostname
+      .replace(/^www\./, "")
+      .toLowerCase();
+    const resources = index.get(hostname) || [];
+    resources.push(normalizedUrl);
+    index.set(hostname, resources);
+  }
+
+  return index;
+}
+
+function findMatchingListedResource(currentUrl, resourceIndex) {
+  const normalizedUrl = normalizeResourceUrl(currentUrl);
+  if (!normalizedUrl) return undefined;
+
+  const hostname = new URL(normalizedUrl).hostname
+    .replace(/^www\./, "")
+    .toLowerCase();
+  const candidateHosts = [hostname];
+
+  // Normal sites can inherit a resource classification from a listed parent
+  // domain. Shared platforms must remain scoped to their exact hostname.
+  if (!isSharedResourceHost(hostname)) {
+    const labels = hostname.split(".");
+    for (let index = 1; index < labels.length - 1; index += 1) {
+      candidateHosts.push(labels.slice(index).join("."));
+    }
+  }
+
+  for (const candidateHost of candidateHosts) {
+    const resources = resourceIndex.get(candidateHost) || [];
+    const match = resources.find((listedUrl) =>
+      urlMatchesListedResource(normalizedUrl, listedUrl)
+    );
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
 function extractRootUrl(url) {
   if (!url) {
     console.warn("Received null or undefined URL for root extraction.");
@@ -979,6 +1032,7 @@ async function fetchFilterLists() {
       fmhyFilterCount: fmhySites.length,
       lastUpdated: new Date().toISOString(),
     });
+    checkedTabUrls.clear();
 
     console.log("Filter lists fetched and stored successfully.");
 
@@ -1022,6 +1076,8 @@ async function fetchSafeSites() {
     safeSites = [
       ...new Set(allUrls.map((url) => normalizeResourceUrl(url.trim()))),
     ].filter((url) => url !== null);
+    safeSiteIndex = buildResourceIndex(safeSites);
+    checkedTabUrls.clear();
 
     // Store safe sites for content script use
     await browserAPI.storage.local.set({
@@ -1064,6 +1120,8 @@ async function fetchStarredSites() {
           .filter((url) => url !== null)
       )
     );
+    starredSiteIndex = buildResourceIndex(starredSites);
+    checkedTabUrls.clear();
 
     await browserAPI.storage.local.set({
       starredSites,
@@ -1131,6 +1189,8 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
+  if (initializationPromise) await initializationPromise;
+
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1163,36 +1223,14 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   // First check the full URL
   status = getStatusFromLists(resourceUrl);
 
-  // If not found, try with trailing slash
-  if (
-    status === "no_data" &&
-    !requiresResourcePath &&
-    !normalizedUrl.endsWith("/")
-  ) {
-    status = getStatusFromLists(normalizedUrl + "/");
-    if (status !== "no_data") matchedUrl = normalizedUrl + "/";
-  }
-
-  // If not found, try without trailing slash
-  if (
-    status === "no_data" &&
-    !requiresResourcePath &&
-    normalizedUrl.endsWith("/")
-  ) {
-    status = getStatusFromLists(normalizedUrl.slice(0, -1));
-    if (status !== "no_data") matchedUrl = normalizedUrl.slice(0, -1);
-  }
-
   // If still no match, check the root URL
-  if (status === "no_data" && !requiresResourcePath) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    rootUrl !== resourceUrl
+  ) {
     status = getStatusFromLists(rootUrl);
     if (status !== "no_data") matchedUrl = rootUrl;
-
-    // Try root URL with trailing slash
-    if (status === "no_data" && !rootUrl.endsWith("/")) {
-      status = getStatusFromLists(rootUrl + "/");
-      if (status !== "no_data") matchedUrl = rootUrl + "/";
-    }
   }
 
   // A path-specific reason can classify a resource even when it is absent from
@@ -1301,6 +1339,8 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
+        if (initializationPromise) await initializationPromise;
+
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1344,17 +1384,25 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         } else if (fmhySitesRegex?.test(normalizedUrl)) {
           status = "fmhy";
           matchedUrl = normalizedUrl;
-        } else if ((matchedUrl = starredSites.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          starredSiteIndex,
+        ))) {
           status = "starred";
-        } else if ((matchedUrl = safeSites.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          safeSiteIndex,
+        ))) {
           status = "safe";
-        } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          base64StarredSiteIndex,
+        ))) {
           status = "starred";
-        } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          base64SafeSiteIndex,
+        ))) {
           status = "safe";
         }
 
@@ -1479,10 +1527,10 @@ function getStatusFromLists(url) {
     if (unsafeSitesRegex?.test(url)) return "unsafe";
     if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
     if (fmhySitesRegex?.test(url)) return "fmhy";
-    if (starredSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
-    if (safeSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
-    if (base64StarredLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
-    if (base64DecodedLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+    if (findMatchingListedResource(url, starredSiteIndex)) return "starred";
+    if (findMatchingListedResource(url, safeSiteIndex)) return "safe";
+    if (findMatchingListedResource(url, base64StarredSiteIndex)) return "starred";
+    if (findMatchingListedResource(url, base64SafeSiteIndex)) return "safe";
 
     if (requiresResourcePath) return "no_data";
 
@@ -1553,14 +1601,26 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
+function shouldCheckTabUrl(tabId, url) {
+  const normalizedUrl = normalizeResourceUrl(url) || url;
+  if (checkedTabUrls.get(tabId) === normalizedUrl) return false;
+
+  checkedTabUrls.set(tabId, normalizedUrl);
+  return true;
+}
+
 // Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-  if (changeInfo.url) {
+  if (changeInfo.url && shouldCheckTabUrl(tabId, changeInfo.url)) {
     await checkSiteAndUpdatePageAction(tabId, changeInfo.url);
     return;
   }
 
-  if (changeInfo.status === "complete" && tab.url) {
+  if (
+    changeInfo.status === "complete" &&
+    tab.url &&
+    shouldCheckTabUrl(tabId, tab.url)
+  ) {
     // Always check the site status
     await checkSiteAndUpdatePageAction(tabId, tab.url);
   }
@@ -1568,8 +1628,8 @@ browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
 browserAPI.tabs.onActivated.addListener(async (activeInfo) => {
   const tab = await browserAPI.tabs.get(activeInfo.tabId);
-  if (tab.url) {
-    checkSiteAndUpdatePageAction(tab.id, tab.url);
+  if (tab.url && shouldCheckTabUrl(tab.id, tab.url)) {
+    await checkSiteAndUpdatePageAction(tab.id, tab.url);
   }
 });
 
@@ -1584,6 +1644,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
+  checkedTabUrls.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 
@@ -1640,6 +1701,7 @@ async function loadUserDomains() {
 browserAPI.storage.onChanged.addListener((changes, area) => {
   if (area === "local") {
     if (changes.userTrustedDomains || changes.userUntrustedDomains) {
+      checkedTabUrls.clear();
       loadUserDomains().then(() => {
         console.log("User domains reloaded after settings change");
       });
@@ -1725,6 +1787,7 @@ async function initializeExtension() {
           storedData.starredSites.length > 0
         ) {
           starredSites = storedData.starredSites;
+          starredSiteIndex = buildResourceIndex(starredSites);
           console.log(
             `Loaded ${starredSites.length} starred sites from storage`
           );
@@ -1742,6 +1805,7 @@ async function initializeExtension() {
           storedData.safeSiteList.length > 0
         ) {
           safeSites = storedData.safeSiteList;
+          safeSiteIndex = buildResourceIndex(safeSites);
           console.log(`Loaded ${safeSites.length} safe sites from storage`);
           const hasLegacyAnchors = Object.values(fmhyResourceMap).some(
             (fmhyUrl) => fmhyUrl.includes("#-")
@@ -1836,4 +1900,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializeExtension();
+initializationPromise = initializeExtension();

--- a/test-builds/chrome/manifest.json
+++ b/test-builds/chrome/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_extensionName__",
     "default_locale": "en",
     "author": "Kenneth Hendricks & contributors",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "icons": {
         "128": "res/ext_icon_144.png"
     },

--- a/test-builds/firefox/js/background.js
+++ b/test-builds/firefox/js/background.js
@@ -127,12 +127,16 @@ let fmhySitesRegex = null;
 let fmhyHostnamesRegex = null; // Domain-only regex for FMHY sites
 let safeSites = [];
 let starredSites = [];
+let safeSiteIndex = new Map();
+let starredSiteIndex = new Map();
 let fmhyResourceMap = {};
 let unsafeReasons = {}; // Object to store reasons for unsafe sites
 const approvedUrls = new Map(); // Map to store approved URLs per tab
+const checkedTabUrls = new Map(); // Last status-checked URL per tab
 const notesCache = new Map(); // Cache for fetched notes
 let userTrustedDomains = new Set(); // User-defined trusted domains
 let userUntrustedDomains = new Set(); // User-defined untrusted domains
+let initializationPromise = null;
 
 // Base64 Starred Links (from rentry.co/FMHYB64) - stored encoded, decoded at runtime
 const base64StarredLinksEncoded = [
@@ -302,6 +306,8 @@ const base64SafeLinksEncoded = [
   "aHR0cHM6Ly9naXRodWIuY29tL0Nvc21pY1NjYWxlL1BTQkJOLURlZmluaXRpdmUtRW5nbGlzaC1QYXRjaA==",
 ];
 const base64DecodedLinks = base64SafeLinksEncoded.map(e => atob(e));
+const base64StarredSiteIndex = buildResourceIndex(base64StarredLinks);
+const base64SafeSiteIndex = buildResourceIndex(base64DecodedLinks);
 
 // List of search engines to check against
 const searchEngines = [
@@ -839,6 +845,53 @@ function urlMatchesListedResource(currentUrl, listedUrl) {
   return true;
 }
 
+function buildResourceIndex(urls) {
+  const index = new Map();
+
+  for (const url of urls) {
+    const normalizedUrl = normalizeResourceUrl(url);
+    if (!normalizedUrl) continue;
+
+    const hostname = new URL(normalizedUrl).hostname
+      .replace(/^www\./, "")
+      .toLowerCase();
+    const resources = index.get(hostname) || [];
+    resources.push(normalizedUrl);
+    index.set(hostname, resources);
+  }
+
+  return index;
+}
+
+function findMatchingListedResource(currentUrl, resourceIndex) {
+  const normalizedUrl = normalizeResourceUrl(currentUrl);
+  if (!normalizedUrl) return undefined;
+
+  const hostname = new URL(normalizedUrl).hostname
+    .replace(/^www\./, "")
+    .toLowerCase();
+  const candidateHosts = [hostname];
+
+  // Normal sites can inherit a resource classification from a listed parent
+  // domain. Shared platforms must remain scoped to their exact hostname.
+  if (!isSharedResourceHost(hostname)) {
+    const labels = hostname.split(".");
+    for (let index = 1; index < labels.length - 1; index += 1) {
+      candidateHosts.push(labels.slice(index).join("."));
+    }
+  }
+
+  for (const candidateHost of candidateHosts) {
+    const resources = resourceIndex.get(candidateHost) || [];
+    const match = resources.find((listedUrl) =>
+      urlMatchesListedResource(normalizedUrl, listedUrl)
+    );
+    if (match) return match;
+  }
+
+  return undefined;
+}
+
 function extractRootUrl(url) {
   if (!url) {
     console.warn("Received null or undefined URL for root extraction.");
@@ -979,6 +1032,7 @@ async function fetchFilterLists() {
       fmhyFilterCount: fmhySites.length,
       lastUpdated: new Date().toISOString(),
     });
+    checkedTabUrls.clear();
 
     console.log("Filter lists fetched and stored successfully.");
 
@@ -1022,6 +1076,8 @@ async function fetchSafeSites() {
     safeSites = [
       ...new Set(allUrls.map((url) => normalizeResourceUrl(url.trim()))),
     ].filter((url) => url !== null);
+    safeSiteIndex = buildResourceIndex(safeSites);
+    checkedTabUrls.clear();
 
     // Store safe sites for content script use
     await browserAPI.storage.local.set({
@@ -1064,6 +1120,8 @@ async function fetchStarredSites() {
           .filter((url) => url !== null)
       )
     );
+    starredSiteIndex = buildResourceIndex(starredSites);
+    checkedTabUrls.clear();
 
     await browserAPI.storage.local.set({
       starredSites,
@@ -1131,6 +1189,8 @@ async function notifySettingsPage() {
 
 // Site Status Checking
 async function checkSiteAndUpdatePageAction(tabId, url) {
+  if (initializationPromise) await initializationPromise;
+
   console.log(
     `checkSiteAndUpdatePageAction: Checking status for ${url} on tab ${tabId}`
   );
@@ -1163,36 +1223,14 @@ async function checkSiteAndUpdatePageAction(tabId, url) {
   // First check the full URL
   status = getStatusFromLists(resourceUrl);
 
-  // If not found, try with trailing slash
-  if (
-    status === "no_data" &&
-    !requiresResourcePath &&
-    !normalizedUrl.endsWith("/")
-  ) {
-    status = getStatusFromLists(normalizedUrl + "/");
-    if (status !== "no_data") matchedUrl = normalizedUrl + "/";
-  }
-
-  // If not found, try without trailing slash
-  if (
-    status === "no_data" &&
-    !requiresResourcePath &&
-    normalizedUrl.endsWith("/")
-  ) {
-    status = getStatusFromLists(normalizedUrl.slice(0, -1));
-    if (status !== "no_data") matchedUrl = normalizedUrl.slice(0, -1);
-  }
-
   // If still no match, check the root URL
-  if (status === "no_data" && !requiresResourcePath) {
+  if (
+    status === "no_data" &&
+    !requiresResourcePath &&
+    rootUrl !== resourceUrl
+  ) {
     status = getStatusFromLists(rootUrl);
     if (status !== "no_data") matchedUrl = rootUrl;
-
-    // Try root URL with trailing slash
-    if (status === "no_data" && !rootUrl.endsWith("/")) {
-      status = getStatusFromLists(rootUrl + "/");
-      if (status !== "no_data") matchedUrl = rootUrl + "/";
-    }
   }
 
   // A path-specific reason can classify a resource even when it is absent from
@@ -1301,6 +1339,8 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "getSiteStatus") {
     (async () => {
       try {
+        if (initializationPromise) await initializationPromise;
+
         // Get the URL from the message
         const url = message.url;
         if (!url) {
@@ -1344,17 +1384,25 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
         } else if (fmhySitesRegex?.test(normalizedUrl)) {
           status = "fmhy";
           matchedUrl = normalizedUrl;
-        } else if ((matchedUrl = starredSites.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          starredSiteIndex,
+        ))) {
           status = "starred";
-        } else if ((matchedUrl = safeSites.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          safeSiteIndex,
+        ))) {
           status = "safe";
-        } else if ((matchedUrl = base64StarredLinks.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          base64StarredSiteIndex,
+        ))) {
           status = "starred";
-        } else if ((matchedUrl = base64DecodedLinks.find((listedUrl) =>
-          urlMatchesListedResource(resourceUrl, listedUrl)))) {
+        } else if ((matchedUrl = findMatchingListedResource(
+          resourceUrl,
+          base64SafeSiteIndex,
+        ))) {
           status = "safe";
         }
 
@@ -1479,10 +1527,10 @@ function getStatusFromLists(url) {
     if (unsafeSitesRegex?.test(url)) return "unsafe";
     if (potentiallyUnsafeSitesRegex?.test(url)) return "potentially_unsafe";
     if (fmhySitesRegex?.test(url)) return "fmhy";
-    if (starredSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
-    if (safeSites.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
-    if (base64StarredLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "starred";
-    if (base64DecodedLinks.some((listedUrl) => urlMatchesListedResource(url, listedUrl))) return "safe";
+    if (findMatchingListedResource(url, starredSiteIndex)) return "starred";
+    if (findMatchingListedResource(url, safeSiteIndex)) return "safe";
+    if (findMatchingListedResource(url, base64StarredSiteIndex)) return "starred";
+    if (findMatchingListedResource(url, base64SafeSiteIndex)) return "safe";
 
     if (requiresResourcePath) return "no_data";
 
@@ -1553,14 +1601,26 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // Don't return anything for messages we don't handle - let other listeners process them
 });
 
+function shouldCheckTabUrl(tabId, url) {
+  const normalizedUrl = normalizeResourceUrl(url) || url;
+  if (checkedTabUrls.get(tabId) === normalizedUrl) return false;
+
+  checkedTabUrls.set(tabId, normalizedUrl);
+  return true;
+}
+
 // Listen for tab updates
 browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-  if (changeInfo.url) {
+  if (changeInfo.url && shouldCheckTabUrl(tabId, changeInfo.url)) {
     await checkSiteAndUpdatePageAction(tabId, changeInfo.url);
     return;
   }
 
-  if (changeInfo.status === "complete" && tab.url) {
+  if (
+    changeInfo.status === "complete" &&
+    tab.url &&
+    shouldCheckTabUrl(tabId, tab.url)
+  ) {
     // Always check the site status
     await checkSiteAndUpdatePageAction(tabId, tab.url);
   }
@@ -1568,8 +1628,8 @@ browserAPI.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
 browserAPI.tabs.onActivated.addListener(async (activeInfo) => {
   const tab = await browserAPI.tabs.get(activeInfo.tabId);
-  if (tab.url) {
-    checkSiteAndUpdatePageAction(tab.id, tab.url);
+  if (tab.url && shouldCheckTabUrl(tab.id, tab.url)) {
+    await checkSiteAndUpdatePageAction(tab.id, tab.url);
   }
 });
 
@@ -1584,6 +1644,7 @@ browserAPI.alarms.onAlarm.addListener(async (alarm) => {
 
 browserAPI.tabs.onRemoved.addListener((tabId) => {
   approvedUrls.delete(tabId);
+  checkedTabUrls.delete(tabId);
   browserAPI.storage.local.remove(`proceedTab_${tabId}`);
 });
 
@@ -1640,6 +1701,7 @@ async function loadUserDomains() {
 browserAPI.storage.onChanged.addListener((changes, area) => {
   if (area === "local") {
     if (changes.userTrustedDomains || changes.userUntrustedDomains) {
+      checkedTabUrls.clear();
       loadUserDomains().then(() => {
         console.log("User domains reloaded after settings change");
       });
@@ -1725,6 +1787,7 @@ async function initializeExtension() {
           storedData.starredSites.length > 0
         ) {
           starredSites = storedData.starredSites;
+          starredSiteIndex = buildResourceIndex(starredSites);
           console.log(
             `Loaded ${starredSites.length} starred sites from storage`
           );
@@ -1742,6 +1805,7 @@ async function initializeExtension() {
           storedData.safeSiteList.length > 0
         ) {
           safeSites = storedData.safeSiteList;
+          safeSiteIndex = buildResourceIndex(safeSites);
           console.log(`Loaded ${safeSites.length} safe sites from storage`);
           const hasLegacyAnchors = Object.values(fmhyResourceMap).some(
             (fmhyUrl) => fmhyUrl.includes("#-")
@@ -1836,4 +1900,4 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 });
 
-initializeExtension();
+initializationPromise = initializeExtension();

--- a/test-builds/firefox/manifest.json
+++ b/test-builds/firefox/manifest.json
@@ -3,7 +3,7 @@
     "name": "__MSG_extensionName__",
     "default_locale": "en",
     "author": "Kenneth Hendricks & contributors",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "icons": {
         "128": "res/ext_icon_144.png"
     },

--- a/tests/content-script-regressions.test.js
+++ b/tests/content-script-regressions.test.js
@@ -169,7 +169,7 @@ test("Markdown autolinks are extracted without angle brackets", () => {
 test("unsafe navigation is checked as soon as the tab URL changes", () => {
   assert.match(
     backgroundScript,
-    /tabs\.onUpdated\.addListener\(async \(tabId, changeInfo, tab\) => \{\s*if \(changeInfo\.url\) \{\s*await checkSiteAndUpdatePageAction\(tabId, changeInfo\.url\);\s*return;/,
+    /tabs\.onUpdated\.addListener\(async \(tabId, changeInfo, tab\) => \{\s*if \(changeInfo\.url && shouldCheckTabUrl\(tabId, changeInfo\.url\)\) \{\s*await checkSiteAndUpdatePageAction\(tabId, changeInfo\.url\);\s*return;/,
   );
 });
 
@@ -460,6 +460,90 @@ test("shared hosts require the same path-bound resource", () => {
   );
 });
 
+test("resource matching only scans candidates for the current hostname", () => {
+  const normalizeUrl = loadFunction(backgroundScript, "normalizeUrl");
+  const normalizeResourceUrl = loadFunctionWithDependencies(
+    backgroundScript,
+    "normalizeResourceUrl",
+    { normalizeUrl },
+  );
+  const buildResourceIndex = loadFunctionWithDependencies(
+    backgroundScript,
+    "buildResourceIndex",
+    { normalizeResourceUrl },
+  );
+
+  let comparisonCount = 0;
+  const findMatchingListedResource = loadFunctionWithDependencies(
+    backgroundScript,
+    "findMatchingListedResource",
+    {
+      normalizeResourceUrl,
+      isSharedResourceHost: () => false,
+      urlMatchesListedResource: (currentUrl, listedUrl) => {
+        comparisonCount += 1;
+        return currentUrl === listedUrl;
+      },
+    },
+  );
+  const resources = Array.from(
+    { length: 25000 },
+    (_, index) => `https://resource-${index}.example/item`,
+  );
+  resources.push("https://target.example/item");
+  const resourceIndex = buildResourceIndex(resources);
+
+  assert.equal(
+    findMatchingListedResource(
+      "https://unknown.example/item",
+      resourceIndex,
+    ),
+    undefined,
+  );
+  assert.equal(comparisonCount, 0);
+
+  assert.equal(
+    findMatchingListedResource(
+      "https://target.example/item",
+      resourceIndex,
+    ),
+    "https://target.example/item",
+  );
+  assert.equal(comparisonCount, 1);
+});
+
+test("the same tab URL is only checked once per navigation", () => {
+  const shouldCheckTabUrl = loadFunctionWithDependencies(
+    backgroundScript,
+    "shouldCheckTabUrl",
+    {
+      normalizeResourceUrl: (url) => url,
+      checkedTabUrls: new Map(),
+    },
+  );
+
+  assert.equal(shouldCheckTabUrl(7, "https://example.com/page"), true);
+  assert.equal(shouldCheckTabUrl(7, "https://example.com/page"), false);
+  assert.equal(shouldCheckTabUrl(7, "https://example.com/next"), true);
+  assert.equal(shouldCheckTabUrl(8, "https://example.com/next"), true);
+});
+
+test("status checks wait for resource-list initialization", () => {
+  assert.match(backgroundScript, /let initializationPromise = null;/);
+  assert.match(
+    backgroundScript,
+    /async function checkSiteAndUpdatePageAction\(tabId, url\) \{\s*if \(initializationPromise\) await initializationPromise;/,
+  );
+  assert.match(
+    backgroundScript,
+    /if \(message\.action === "getSiteStatus"\) \{\s*\(async \(\) => \{\s*try \{\s*if \(initializationPromise\) await initializationPromise;/,
+  );
+  assert.match(
+    backgroundScript,
+    /initializationPromise = initializeExtension\(\);/,
+  );
+});
+
 test("cross-domain redirects do not inherit a source site's status", () => {
   assert.doesNotMatch(chromiumManifest, /"webNavigation"/);
   assert.doesNotMatch(firefoxManifest, /"webNavigation"|"webRequest"/);
@@ -532,6 +616,30 @@ test("status matching isolates shared resources and recognizes matching subdomai
     "urlMatchesListedResource",
     { normalizeResourceUrl, isSharedResourceHost },
   );
+  const buildResourceIndex = loadFunctionWithDependencies(
+    backgroundScript,
+    "buildResourceIndex",
+    { normalizeResourceUrl },
+  );
+  const findMatchingListedResource = loadFunctionWithDependencies(
+    backgroundScript,
+    "findMatchingListedResource",
+    {
+      normalizeResourceUrl,
+      isSharedResourceHost,
+      urlMatchesListedResource,
+    },
+  );
+  const starredSiteIndex = buildResourceIndex([
+    "https://github.com/fmhy/FMHY-SafeGuard",
+    "https://gist.github.com/",
+    "https://docs.gitlab.com/user/snippets/",
+    "https://ente.com/auth",
+    "https://mullvad.net",
+  ]);
+  const safeSiteIndex = buildResourceIndex([
+    "https://github.com/fmhy/FMHYFilterlist",
+  ]);
   const getStatusFromLists = loadFunctionWithDependencies(
     backgroundScript,
     "getStatusFromLists",
@@ -539,20 +647,14 @@ test("status matching isolates shared resources and recognizes matching subdomai
       userTrustedDomains: new Set(),
       userUntrustedDomains: new Set(),
       isSharedResourceHost,
-      urlMatchesListedResource,
+      findMatchingListedResource,
       unsafeSitesRegex: null,
       potentiallyUnsafeSitesRegex: null,
       fmhySitesRegex: null,
-      starredSites: [
-        "https://github.com/fmhy/FMHY-SafeGuard",
-        "https://gist.github.com/",
-        "https://docs.gitlab.com/user/snippets/",
-        "https://ente.com/auth",
-        "https://mullvad.net",
-      ],
-      safeSites: ["https://github.com/fmhy/FMHYFilterlist"],
-      base64StarredLinks: [],
-      base64DecodedLinks: [],
+      starredSiteIndex,
+      safeSiteIndex,
+      base64StarredSiteIndex: new Map(),
+      base64SafeSiteIndex: new Map(),
       unsafeHostnamesRegex: null,
       potentiallyUnsafeHostnamesRegex: null,
     },
@@ -663,7 +765,7 @@ test("live resource data preserves query and fragment identities", () => {
   );
   assert.match(
     backgroundScript,
-    /urlMatchesListedResource\(resourceUrl, listedUrl\)/,
+    /findMatchingListedResource\(\s*resourceUrl,\s*(?:starred|safe)SiteIndex,/,
   );
   assert.match(
     backgroundScript,
@@ -678,7 +780,7 @@ test("the toolbar does not inherit root status on shared hosts", () => {
   );
   assert.match(
     backgroundScript,
-    /if \(status === "no_data" && !requiresResourcePath\) \{\s*status = getStatusFromLists\(rootUrl\);/,
+    /status === "no_data" &&\s*!requiresResourcePath &&\s*rootUrl !== resourceUrl\s*\) \{\s*status = getStatusFromLists\(rootUrl\);/,
   );
 });
 

--- a/updates.json
+++ b/updates.json
@@ -3,8 +3,8 @@
     "{5d554479-7cc4-487f-bd25-d8fc67a42602}": {
       "updates": [
         {
-          "version": "1.3.8",
-          "update_link": "https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.8/FMHY-SafeGuard_v1.3.8.firefox.xpi"
+          "version": "1.3.9",
+          "update_link": "https://github.com/fmhy/FMHY-SafeGuard/releases/download/v1.3.9/FMHY-SafeGuard_v1.3.9.firefox.xpi"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- index FMHY resources by hostname to avoid full-list scans on every navigation
- deduplicate repeated checks for the same tab URL and wait for list initialization
- release the CPU regression fix as v1.3.9 across manifests, update metadata, test builds, and release notes

## Testing
- `node --test tests/content-script-regressions.test.js` (32 passed)
- syntax checked all source JavaScript with `node --check`
- verified all 40 source files match both committed test builds
- packaged Chromium and Firefox archives locally and verified root layout/version
- `web-ext lint` completed with 0 errors
- profiled Firefox before/after: patched build returned CPU usage to control levels